### PR TITLE
Add support for kairosdb

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ type conf struct {
 	RabbitMQURL         string `toml:"rabbitmq-url"`
 	GraphiteAddr        string `toml:"graphite-addr"`
 	GraphitePort        int    `toml:"graphite-port"`
+	KairosdbHostPort    string `toml:"kairosdb-host"`
 	ElasticsearchDomain string `toml:"elasticsearch-domain"`
 	ElasticsearchPort   int    `toml:"elasticsearch-port"`
 	ElasticsearchUser   string `toml:"elasticsearch-user"`
@@ -55,6 +56,7 @@ type options struct {
 	SysLog              bool   `short:"s" long:"syslog" description:"Log to syslog rather than a log file. Incompatible with -L/--log-file."`
 	GraphiteAddr        string `short:"g" long:"graphite-addr" description:"Graphite IP address or hostname."`
 	GraphitePort        int    `short:"p" long:"graphite-port" description:"Port graphite listens on."`
+	KairosdbHostPort    string `short:"k" long:"kairosdb-host" description:"KairosDB host:port"`
 	ElasticsearchDomain string `short:"d" long:"elasticsearch-domain" description:"Elasticseach domain."`
 	ElasticsearchPort   int    `short:"t" long:"elasticsearch-port" description:"Port to connect to for Elasticsearch, defaults to 9200."`
 	ElasticsearchUser   string `short:"u" long:"elasticsearch-user" description:"Optional username to use when connecting to elasticsearch."`
@@ -145,6 +147,9 @@ func parseConfig() error {
 	}
 	if opts.GraphiteAddr != "" {
 		config.GraphiteAddr = opts.GraphiteAddr
+	}
+	if opts.KairosdbHostPort != "" {
+		config.KairosdbHostPort = opts.KairosdbHostPort
 	}
 	if opts.GraphitePort != 0 {
 		config.GraphitePort = opts.GraphitePort

--- a/etc/raintank-sample.conf
+++ b/etc/raintank-sample.conf
@@ -4,6 +4,8 @@ rabbitmq-url = "amqp://rabbitmq.local"
 graphite-addr = "influxdb.local"
 # graphite (or compatible) port
 graphite-port = 2003
+# kairosdb api address
+kairosdb-host = "http://kairosdb:8080"
 # Elasticsearch's domain
 elasticsearch-domain = "elasticsearch.local"
 # Optional elasticsearch items:

--- a/metricstore/influxdb.go
+++ b/metricstore/influxdb.go
@@ -1,0 +1,33 @@
+package metricstore
+
+import (
+	"strconv"
+	"github.com/marpaia/graphite-golang"
+	"github.com/raintank/raintank-metric/metricdef"
+)
+
+// Kairosdb client
+type Influxdb struct {
+	Graphite *graphite.Graphite
+}
+
+func NewInfluxdb(host string, port int) (*Influxdb, error) {
+	graphite, err := graphite.NewGraphite(host, port)
+	if err != nil {
+		return nil, err
+	} 
+	return &Influxdb{ Graphite: graphite }, nil
+}
+
+func (influx Influxdb) SendMetrics(metrics *[]metricdef.IndvMetric) error {
+	// marshal metrics into datapoint structs
+	datapoints := make([]graphite.Metric, len(*metrics))
+	for i, m := range *metrics {
+		datapoints[i] = graphite.Metric{
+			Name: m.Id,
+			Timestamp: m.Time,
+			Value: strconv.FormatFloat(m.Value, 'f', -1, 64),
+		}
+	}
+	return influx.Graphite.SendMetrics(datapoints)
+}

--- a/metricstore/kairosdb.go
+++ b/metricstore/kairosdb.go
@@ -38,10 +38,11 @@ func (kdb *Kairosdb) SendMetrics(metrics *[]metricdef.IndvMetric) error {
 	// marshal metrics into datapoint structs
 	datapoints := make([]Datapoint, len(*metrics))
 	for i, m := range *metrics {
-		tags := make(map[string]string, len(m.Extra))
+		tags := make(map[string]string)
 		for k,v := range m.Extra {
 			tags[k] = fmt.Sprintf("%v", v)
 		}
+		tags["org_id"] = fmt.Sprintf("%v", m.OrgId)
 		datapoints[i] = Datapoint{
 			Name: m.Metric,
 			Timestamp: m.Time * 1000,
@@ -57,7 +58,6 @@ func (kdb *Kairosdb) SendMetrics(metrics *[]metricdef.IndvMetric) error {
 func (kdb *Kairosdb) AddDatapoints(datapoints []Datapoint) error {
 
 	json, err := json.Marshal(datapoints)
-	logger.Debugf("sending datapoints to kairosdb. %s", json)
 	if err != nil {
 		return err
 	}

--- a/metricstore/kairosdb.go
+++ b/metricstore/kairosdb.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 	"github.com/raintank/raintank-metric/metricdef"
+	"github.com/ctdk/goas/v2/logger"
 )
 
 // Kairosdb client
@@ -17,6 +18,7 @@ type Kairosdb struct {
 }
 
 func NewKairosdb(host string) (*Kairosdb, error) {
+	logger.Debugf("initializing kairosdb client to %s", host)
 	return &Kairosdb{
 		client: &http.Client{Timeout: (10 * time.Second)},
 		host: host,
@@ -41,8 +43,8 @@ func (kdb *Kairosdb) SendMetrics(metrics *[]metricdef.IndvMetric) error {
 			tags[k] = fmt.Sprintf("%v", v)
 		}
 		datapoints[i] = Datapoint{
-			Name: m.Name,
-			Timestamp: m.Time,
+			Name: m.Metric,
+			Timestamp: m.Time * 1000,
 			Value: m.Value,
 			Tags: tags,
 		}
@@ -55,6 +57,7 @@ func (kdb *Kairosdb) SendMetrics(metrics *[]metricdef.IndvMetric) error {
 func (kdb *Kairosdb) AddDatapoints(datapoints []Datapoint) error {
 
 	json, err := json.Marshal(datapoints)
+	logger.Debugf("sending datapoints to kairosdb. %s", json)
 	if err != nil {
 		return err
 	}

--- a/metricstore/kairosdb.go
+++ b/metricstore/kairosdb.go
@@ -1,0 +1,70 @@
+package metricstore
+
+import (
+	"bytes"
+	"fmt"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+	"github.com/raintank/raintank-metric/metricdef"
+)
+
+// Kairosdb client
+type Kairosdb struct {
+	client *http.Client
+	host   string
+}
+
+func NewKairosdb(host string) (*Kairosdb, error) {
+	return &Kairosdb{
+		client: &http.Client{Timeout: (10 * time.Second)},
+		host: host,
+	}, nil
+}
+
+// Datapoint instances are persisted back to kairosdb via AddDatapoints
+type Datapoint struct {
+	Name      string            `json:"name"`
+	Timestamp int64             `json:"timestamp"`
+	Value     float64           `json:"value"`
+	Tags      map[string]string `json:"tags"`
+}
+
+
+func (kdb *Kairosdb) SendMetrics(metrics *[]metricdef.IndvMetric) error {
+	// marshal metrics into datapoint structs
+	datapoints := make([]Datapoint, len(*metrics))
+	for i, m := range *metrics {
+		tags := make(map[string]string, len(m.Extra))
+		for k,v := range m.Extra {
+			tags[k] = fmt.Sprintf("%v", v)
+		}
+		datapoints[i] = Datapoint{
+			Name: m.Name,
+			Timestamp: m.Time,
+			Value: m.Value,
+			Tags: tags,
+		}
+	}
+	return kdb.AddDatapoints(datapoints)
+}
+
+
+// AddDatapoints add datapoints to configured kairosdb instance
+func (kdb *Kairosdb) AddDatapoints(datapoints []Datapoint) error {
+
+	json, err := json.Marshal(datapoints)
+	if err != nil {
+		return err
+	}
+	resp, err := kdb.client.Post(kdb.host+"/api/v1/datapoints", "application/json", bytes.NewBuffer(json))
+	if err != nil {
+		return err
+	}
+	if resp.Status != "204 No Content" {
+		return errors.New("Response was non-200: " + resp.Status)
+	}
+	return nil
+}
+

--- a/metricstore/metricstore.go
+++ b/metricstore/metricstore.go
@@ -54,12 +54,15 @@ func (mStore MetricStore) ProcessBuffer(c <-chan metricdef.IndvMetric, workerId 
 			logger.Debugf("worker %d flushing %d items in buffer now", workerId, len(currentBuf))
 			if err := mStore.InfluxDB.SendMetrics(&currentBuf); err != nil {
 				logger.Errorf(err.Error())
+			} else {
+				logger.Debugf("worker %d flushed metrics buffer to Influxdb", workerId)
 			}
-			logger.Debugf("worker %d flushed metrics buffer to Influxdb", workerId)
+
 			if err := mStore.KairosDB.SendMetrics(&currentBuf); err != nil {
 				logger.Errorf(err.Error())
+			} else {
+				logger.Debugf("worker %d flushed metrics buffer to Kairosdb", workerId)
 			}
-			logger.Debugf("worker %d flushed metrics buffer to Kairosdb", workerId)
 		}
 	}
 }

--- a/metricstore/metricstore.go
+++ b/metricstore/metricstore.go
@@ -1,0 +1,65 @@
+package metricstore
+
+import (
+	"time"
+	"github.com/raintank/raintank-metric/metricdef"
+	"github.com/ctdk/goas/v2/logger"
+)
+
+type MetricStore struct {
+	KairosDB *Kairosdb
+	InfluxDB *Influxdb
+}
+
+func NewMetricStore(GraphiteAddr string, GraphitePort int, KairosdbHostPort string) (*MetricStore, error) {
+	
+	kairosdb, err := NewKairosdb(KairosdbHostPort)
+	if err != nil {
+		return nil, err
+	}
+
+	influx, err := NewInfluxdb(GraphiteAddr, GraphitePort)
+	if err != nil {
+		return nil, err
+	}
+	mStore := MetricStore{
+		KairosDB: kairosdb,
+		InfluxDB: influx,
+	}
+	return &mStore, nil
+}
+
+
+func (mStore MetricStore) ProcessBuffer(c <-chan metricdef.IndvMetric, workerId int) {
+	buf := make([]metricdef.IndvMetric, 0)
+
+	// flush buffer every second
+	t := time.NewTicker(time.Second)
+	for {
+		select {
+		case b := <-c:
+			if b.Name != "" {
+				logger.Debugf("worker %d appending to buffer", workerId)
+				buf = append(buf, b)
+			}
+		case <-t.C:
+			// A possibility: it might be worth it to hack up the
+			// carbon lib to allow batch submissions of metrics if
+			// doing them individually proves to be too slow
+
+			//copy contents of buffer
+			currentBuf := make([]metricdef.IndvMetric, len(buf))
+			copy(currentBuf, buf)
+			buf = nil
+			logger.Debugf("worker %d flushing %d items in buffer now", workerId, len(currentBuf))
+			if err := mStore.InfluxDB.SendMetrics(&currentBuf); err != nil {
+				logger.Errorf(err.Error())
+			}
+			logger.Debugf("worker %d flushed metrics buffer to Influxdb", workerId)
+			if err := mStore.KairosDB.SendMetrics(&currentBuf); err != nil {
+				logger.Errorf(err.Error())
+			}
+			logger.Debugf("worker %d flushed metrics buffer to Kairosdb", workerId)
+		}
+	}
+}


### PR DESCRIPTION
splits metric storage component into separate package.  Every metric received is written to both kairosdb and influxdb