### PR TITLE
Grafana logging package with nsq_* tools

### DIFF
--- a/etc/raintank/metric_tank-sample.ini
+++ b/etc/raintank/metric_tank-sample.ini
@@ -3,3 +3,4 @@ channel = tank
 topic = metrics
 nsqd-tcp-address = localhost:4150,1.2.3.4:4150,5.6.7.8:4150
 cassandra-addrs = localhost
+listen = :6060

--- a/etc/raintank/nsq_metrics_to_elasticsearch-sample.ini
+++ b/etc/raintank/nsq_metrics_to_elasticsearch-sample.ini
@@ -6,3 +6,4 @@ statsd-addr = localhost:8125
 statsd-type = datadog
 elastic-addr = localhost:9200
 redis-addr = localhost:6379
+listen = :6060

--- a/etc/raintank/nsq_metrics_to_kairos-sample.ini
+++ b/etc/raintank/nsq_metrics_to_kairos-sample.ini
@@ -4,3 +4,4 @@ topic = metrics
 topic-lowprio = metrics-lowprio
 nsqd-tcp-address = localhost:4150
 kairos-addr = localhost:8080
+listen = :6060

--- a/etc/raintank/nsq_probe_events_to_elasticsearch-sample.ini
+++ b/etc/raintank/nsq_probe_events_to_elasticsearch-sample.ini
@@ -3,3 +3,4 @@ channel = elasticsearch
 topic = probe_events
 nsqd-tcp-address = localhost:4150
 elastic-addr = localhost:9200
+listen = :6060

--- a/eventdef/eventdef.go
+++ b/eventdef/eventdef.go
@@ -18,7 +18,7 @@ package eventdef
 
 import (
 	"fmt"
-	"log"
+	"github.com/grafana/grafana/pkg/log"
 	"strings"
 	"time"
 
@@ -57,9 +57,9 @@ func Save(e *schema.ProbeEvent) error {
 	if err := e.Validate(); err != nil {
 		return err
 	}
-	log.Printf("saving event to elasticsearch.")
+	log.Debug("saving event to elasticsearch.")
 	resp, err := es.Index("events", e.EventType, e.Id, nil, e)
-	log.Printf("elasticsearch response: %v", resp)
+	log.Debug("elasticsearch response: %v", resp)
 	if err != nil {
 		return err
 	}

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -99,7 +99,7 @@ func main() {
 	if _, err := os.Stat(*confFile); err == nil {
 		conf, err := globalconf.NewWithOptions(&globalconf.Options{Filename: *confFile})
 		if err != nil {
-			log.Fatal(0, "error with configuration file: %s", err)
+			log.Fatal(4, "error with configuration file: %s", err)
 			os.Exit(1)
 		}
 		conf.ParseAll()
@@ -164,7 +164,7 @@ func main() {
 	err = InitCassandra()
 
 	if err != nil {
-		log.Fatal(0, "failed to initialize cassandra. %s", err)
+		log.Fatal(4, "failed to initialize cassandra. %s", err)
 	}
 
 	metrics = NewAggMetrics(uint32(*chunkSpan), uint32(*numChunks), uint32(300), uint32(3600*2), 1)
@@ -177,7 +177,7 @@ func main() {
 	}
 	err = consumer.ConnectToNSQDs(nsqdAdds)
 	if err != nil {
-		log.Fatal(0, "failed to connect to NSQDs. %s", err)
+		log.Fatal(4, "failed to connect to NSQDs. %s", err)
 	}
 	log.Info("connected to nsqd")
 
@@ -187,7 +187,7 @@ func main() {
 	}
 	err = consumer.ConnectToNSQLookupds(lookupdAdds)
 	if err != nil {
-		log.Fatal(0, "failed to connect to NSQLookupds. %s", err)
+		log.Fatal(4, "failed to connect to NSQLookupds. %s", err)
 	}
 
 	go func() {
@@ -211,7 +211,7 @@ func main() {
 		case <-consumer.StopChan:
 			err := metrics.Persist()
 			if err != nil {
-				log.Error(0, "failed to persist aggmetrics. %s", err)
+				log.Error(3, "failed to persist aggmetrics. %s", err)
 			}
 			log.Info("closing cassandra session.")
 			cSession.Close()

--- a/nsq_metrics_to_elasticsearch/nsq_metrics_to_elasticsearch.go
+++ b/nsq_metrics_to_elasticsearch/nsq_metrics_to_elasticsearch.go
@@ -113,7 +113,6 @@ func main() {
 		conf, err := globalconf.NewWithOptions(&globalconf.Options{Filename: *confFile})
 		if err != nil {
 			log.Fatal(3, "Could not parse config file. %s", err)
-			os.Exit(1)
 		}
 		conf.ParseAll()
 	}

--- a/nsq_metrics_to_elasticsearch/nsq_metrics_to_elasticsearch.go
+++ b/nsq_metrics_to_elasticsearch/nsq_metrics_to_elasticsearch.go
@@ -43,6 +43,7 @@ var (
 	lookupdHTTPAddrs = flag.String("lookupd-http-address", "", "lookupd HTTP address (may be given multiple times as comma-separated list)")
 
 	logLevel = flag.Int("log-level", 2, "log level. 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=ERROR|5=CRITICAL|6=FATAL")
+	listenAddr = flag.String("listen", ":6060", "http listener address.")
 
 	metricsToEsOK     met.Count
 	metricsToEsFail   met.Count
@@ -210,8 +211,8 @@ func main() {
 		log.Fatal(4, "failed to connect to nsqlookupd. %s", err)
 	}
 	go func() {
-		log.Info("INFO starting listener for http/debug on :6060")
-		log.Info("%s", http.ListenAndServe(":6060", nil))
+		log.Info("INFO starting listener for http/debug on %s", *listenAddr)
+		log.Info("%s", http.ListenAndServe(*listenAddr, nil))
 	}()
 
 	for {

--- a/nsq_metrics_to_kairos/kairosgateway.go
+++ b/nsq_metrics_to_kairos/kairosgateway.go
@@ -85,7 +85,7 @@ func (kg *KairosGateway) process(job Job) error {
 
 	err := job.Msg.DecodeMetricData()
 	if err != nil {
-		log.Info(err, "skipping message")
+		log.Info("%s: skipping message", err.Error())
 		return nil
 	}
 

--- a/nsq_metrics_to_kairos/kairosgateway.go
+++ b/nsq_metrics_to_kairos/kairosgateway.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"log"
 	"time"
 
 	"github.com/nsqio/go-nsq"
+	"github.com/grafana/grafana/pkg/log"
 	"github.com/raintank/raintank-metric/metricstore"
 )
 
@@ -81,11 +81,11 @@ func (kg *KairosGateway) ProcessLowPrio(msg *nsq.Message) error {
 func (kg *KairosGateway) process(job Job) error {
 	msg := job.msg
 	messagesSize.Value(int64(len(job.Msg.Msg)))
-	log.Printf("DEBUG: processing metrics %s %d. timestamp: %s. format: %s. attempts: %d\n", job.qualifier, job.Msg.Id, time.Unix(0, msg.Timestamp), job.Msg.Format, msg.Attempts)
+	log.Debug("processing metrics %s %d. timestamp: %s. format: %s. attempts: %d\n", job.qualifier, job.Msg.Id, time.Unix(0, msg.Timestamp), job.Msg.Format, msg.Attempts)
 
 	err := job.Msg.DecodeMetricData()
 	if err != nil {
-		log.Println(err, "skipping message")
+		log.Info(err, "skipping message")
 		return nil
 	}
 
@@ -95,12 +95,12 @@ func (kg *KairosGateway) process(job Job) error {
 		err = kg.kairos.SendMetricPointers(job.Msg.Metrics)
 		if err != nil {
 			metricsToKairosFail.Inc(int64(len(job.Msg.Metrics)))
-			log.Printf("WARNING: can't send to kairosdb: %s. retrying later", err)
+			log.Warn("can't send to kairosdb: %s. retrying later", err)
 		} else {
 			metricsToKairosOK.Inc(int64(len(job.Msg.Metrics)))
 			kairosPutDuration.Value(time.Now().Sub(pre))
 		}
 	}
-	log.Printf("DEBUG: finished metrics %s %d - %d metrics sent\n", job.qualifier, job.Msg.Id, len(job.Msg.Metrics))
+	log.Debug("finished metrics %s %d - %d metrics sent\n", job.qualifier, job.Msg.Id, len(job.Msg.Metrics))
 	return err
 }

--- a/nsq_metrics_to_kairos/nsq_metrics_to_kairos.go
+++ b/nsq_metrics_to_kairos/nsq_metrics_to_kairos.go
@@ -45,6 +45,7 @@ var (
 	nsqdTCPAddrs     = flag.String("nsqd-tcp-address", "", "nsqd TCP address (may be given multiple times as comma-separated list)")
 	lookupdHTTPAddrs = flag.String("lookupd-http-address", "", "lookupd HTTP address (may be given multiple times as comma-separated list)")
 	logLevel = flag.Int("log-level", 2, "log level. 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=ERROR|5=CRITICAL|6=FATAL")
+	listenAddr = flag.String("listen", ":6060", "http listener address.")
 )
 
 var metricsToKairosOK met.Count
@@ -132,7 +133,7 @@ func main() {
 	pCfg.UserAgent = "nsq_metrics_to_kairos"
 	err = app.ParseOpts(pCfg, *producerOpts)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(0, err.Error())
 	}
 
 	metricsToKairosOK = metrics.NewCount("metrics_to_kairos.ok")
@@ -156,7 +157,7 @@ func main() {
 	for _, addr := range strings.Split(*nsqdTCPAddrs, ",") {
 		producer, err := nsq.NewProducer(addr, pCfg)
 		if err != nil {
-			log.Fatalf(0, "failed creating producer %s", err.Error())
+			log.Fatal(0, "failed creating producer %s", err.Error())
 		}
 		producers[addr] = producer
 	}
@@ -203,8 +204,8 @@ func main() {
 	}
 
 	go func() {
-		log.Info("starting listener for http/debug on :6060")
-		log.Info("%s", http.ListenAndServe(":6060", nil))
+		log.Info("starting listener for http/debug on %s", *listenAddr)
+		log.Info("%s", http.ListenAndServe(*listenAddr, nil))
 	}()
 
 	for {

--- a/nsq_metrics_to_stdout/nsq_metrics_to_stdout.go
+++ b/nsq_metrics_to_stdout/nsq_metrics_to_stdout.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
@@ -14,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/grafana/grafana/pkg/log"
 	"github.com/nsqio/go-nsq"
 	"github.com/raintank/raintank-metric/app"
 	"github.com/raintank/raintank-metric/msg"
@@ -29,6 +29,7 @@ var (
 	consumerOpts     = flag.String("consumer-opt", "", "option to passthrough to nsq.Consumer (may be given multiple times as comma-separated list, http://godoc.org/github.com/nsqio/go-nsq#Config)")
 	nsqdTCPAddrs     = flag.String("nsqd-tcp-address", "", "nsqd TCP address (may be given multiple times as comma-separated list)")
 	lookupdHTTPAddrs = flag.String("lookupd-http-address", "", "lookupd HTTP address (may be given multiple times as comma-separated list)")
+	logLevel = flag.Int("log-level", 2, "log level. 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=ERROR|5=CRITICAL|6=FATAL")
 )
 
 type StdoutHandler struct {
@@ -42,13 +43,13 @@ func NewStdoutHandler() (*StdoutHandler, error) {
 func (k *StdoutHandler) HandleMessage(m *nsq.Message) error {
 	ms, err := msg.MetricDataFromMsg(m.Body)
 	if err != nil {
-		log.Println("ERROR:", err, "skipping message")
+		log.Error(0, "%s: skipping message", err.Error())
 		return nil
 	}
 
 	err = ms.DecodeMetricData()
 	if err != nil {
-		log.Println("ERROR:", err, "skipping message")
+		log.Error(0, "%s: skipping message", err.Error())
 		return nil
 	}
 
@@ -61,6 +62,8 @@ func (k *StdoutHandler) HandleMessage(m *nsq.Message) error {
 func main() {
 	flag.Parse()
 
+	log.NewLogger(0, "console", fmt.Sprintf(`{"level": %d, "formatting":true}`, *logLevel))
+
 	if *showVersion {
 		fmt.Println("nsq_metrics_to_stdout")
 		return
@@ -72,7 +75,7 @@ func main() {
 	}
 
 	if *topic == "" {
-		log.Fatal("--topic is required")
+		log.Fatal(0, "--topic is required")
 	}
 
 	if *nsqdTCPAddrs == "" && *lookupdHTTPAddrs == "" {
@@ -89,18 +92,18 @@ func main() {
 	cfg.UserAgent = "nsq_metrics_to_stdout"
 	err := app.ParseOpts(cfg, *consumerOpts)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(0, err.Error())
 	}
 	cfg.MaxInFlight = *maxInFlight
 
 	consumer, err := nsq.NewConsumer(*topic, *channel, cfg)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(0, err.Error())
 	}
 
 	handler, err := NewStdoutHandler()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(0, err.Error())
 	}
 
 	consumer.AddHandler(handler)
@@ -111,9 +114,9 @@ func main() {
 	}
 	err = consumer.ConnectToNSQDs(nsqdAdds)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(0, err.Error())
 	}
-	log.Println("connected to nsqd")
+	log.Info("connected to nsqd")
 
 	lookupdAdds := strings.Split(*lookupdHTTPAddrs, ",")
 	if len(lookupdAdds) == 1 && lookupdAdds[0] == "" {
@@ -121,11 +124,11 @@ func main() {
 	}
 	err = consumer.ConnectToNSQLookupds(lookupdAdds)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(0, err.Error())
 	}
 	go func() {
-		log.Println("INFO starting listener for http/debug on :6060")
-		log.Println(http.ListenAndServe(":6060", nil))
+		log.Info("starting listener for http/debug on :6060")
+		log.Info("%s", http.ListenAndServe(":6060", nil))
 	}()
 
 	for {

--- a/nsq_metrics_to_stdout/nsq_metrics_to_stdout.go
+++ b/nsq_metrics_to_stdout/nsq_metrics_to_stdout.go
@@ -44,13 +44,13 @@ func NewStdoutHandler() (*StdoutHandler, error) {
 func (k *StdoutHandler) HandleMessage(m *nsq.Message) error {
 	ms, err := msg.MetricDataFromMsg(m.Body)
 	if err != nil {
-		log.Error(0, "%s: skipping message", err.Error())
+		log.Error(3, "%s: skipping message", err.Error())
 		return nil
 	}
 
 	err = ms.DecodeMetricData()
 	if err != nil {
-		log.Error(0, "%s: skipping message", err.Error())
+		log.Error(3, "%s: skipping message", err.Error())
 		return nil
 	}
 
@@ -76,14 +76,14 @@ func main() {
 	}
 
 	if *topic == "" {
-		log.Fatal(0, "--topic is required")
+		log.Fatal(4, "--topic is required")
 	}
 
 	if *nsqdTCPAddrs == "" && *lookupdHTTPAddrs == "" {
-		log.Fatal(0, "--nsqd-tcp-address or --lookupd-http-address required")
+		log.Fatal(4, "--nsqd-tcp-address or --lookupd-http-address required")
 	}
 	if *nsqdTCPAddrs != "" && *lookupdHTTPAddrs != "" {
-		log.Fatal(0, "use --nsqd-tcp-address or --lookupd-http-address not both")
+		log.Fatal(4, "use --nsqd-tcp-address or --lookupd-http-address not both")
 	}
 
 	sigChan := make(chan os.Signal, 1)
@@ -93,18 +93,18 @@ func main() {
 	cfg.UserAgent = "nsq_metrics_to_stdout"
 	err := app.ParseOpts(cfg, *consumerOpts)
 	if err != nil {
-		log.Fatal(0, err.Error())
+		log.Fatal(4, err.Error())
 	}
 	cfg.MaxInFlight = *maxInFlight
 
 	consumer, err := nsq.NewConsumer(*topic, *channel, cfg)
 	if err != nil {
-		log.Fatal(0, err.Error())
+		log.Fatal(4, err.Error())
 	}
 
 	handler, err := NewStdoutHandler()
 	if err != nil {
-		log.Fatal(0, err.Error())
+		log.Fatal(4, err.Error())
 	}
 
 	consumer.AddHandler(handler)
@@ -115,7 +115,7 @@ func main() {
 	}
 	err = consumer.ConnectToNSQDs(nsqdAdds)
 	if err != nil {
-		log.Fatal(0, err.Error())
+		log.Fatal(4, err.Error())
 	}
 	log.Info("connected to nsqd")
 
@@ -125,7 +125,7 @@ func main() {
 	}
 	err = consumer.ConnectToNSQLookupds(lookupdAdds)
 	if err != nil {
-		log.Fatal(0, err.Error())
+		log.Fatal(4, err.Error())
 	}
 	go func() {
 		log.Info("starting listener for http/debug on %s", *listenAddr)

--- a/nsq_metrics_to_stdout/nsq_metrics_to_stdout.go
+++ b/nsq_metrics_to_stdout/nsq_metrics_to_stdout.go
@@ -30,6 +30,7 @@ var (
 	nsqdTCPAddrs     = flag.String("nsqd-tcp-address", "", "nsqd TCP address (may be given multiple times as comma-separated list)")
 	lookupdHTTPAddrs = flag.String("lookupd-http-address", "", "lookupd HTTP address (may be given multiple times as comma-separated list)")
 	logLevel = flag.Int("log-level", 2, "log level. 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=ERROR|5=CRITICAL|6=FATAL")
+	listenAddr = flag.String("listen", ":6060", "http listener address.")
 )
 
 type StdoutHandler struct {
@@ -127,8 +128,8 @@ func main() {
 		log.Fatal(0, err.Error())
 	}
 	go func() {
-		log.Info("starting listener for http/debug on :6060")
-		log.Info("%s", http.ListenAndServe(":6060", nil))
+		log.Info("starting listener for http/debug on %s", *listenAddr)
+		log.Info("%s", http.ListenAndServe(*listenAddr, nil))
 	}()
 
 	for {

--- a/nsq_probe_events_to_elasticsearch/nsq_probe_events_to_elasticsearch.go
+++ b/nsq_probe_events_to_elasticsearch/nsq_probe_events_to_elasticsearch.go
@@ -46,6 +46,7 @@ var (
 	nsqdTCPAddrs     = flag.String("nsqd-tcp-address", "", "nsqd TCP address (may be given multiple times as comma-separated list)")
 	lookupdHTTPAddrs = flag.String("lookupd-http-address", "", "lookupd HTTP address (may be given multiple times as comma-separated list)")
 	logLevel = flag.Int("log-level", 2, "log level. 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=ERROR|5=CRITICAL|6=FATAL")
+	listenAddr = flag.String("listen", ":6060", "http listener address.")
 
 	eventsToEsOK   met.Count
 	eventsToEsFail met.Count
@@ -209,8 +210,8 @@ func main() {
 		log.Fatal(0, err.Error())
 	}
 	go func() {
-		log.Info("INFO starting listener for http/debug on :6060")
-		httperr := http.ListenAndServe(":6060", nil)
+		log.Info("INFO starting listener for http/debug on %s", *listenAddr)
+		httperr := http.ListenAndServe(*listenAddr, nil)
 		if httperr != nil {
 			log.Info(httperr.Error())
 		}


### PR DESCRIPTION
What it says on the tin: switch these tools over to using the grafana logging package with its log levels and such. Also, for the ones that aren't metric_tank (since it already has it) add a `-listen` flag to let us specify an address; I've noticed in testing that these programs all try and listen on :6060 when running on the same machine.