### PR TITLE
Do chunk & metric GC based on when they were last written to. fix #50

### DIFF
--- a/metric_tank/aggmetric.go
+++ b/metric_tank/aggmetric.go
@@ -345,10 +345,10 @@ func (a *AggMetric) GC(chunkMinTs, metricMinTs uint32) bool {
 		return false
 	}
 
-	if currentChunk.T0 < chunkMinTs {
+	if currentChunk.LastWrite < chunkMinTs {
 		if currentChunk.Saved {
 			// already saved. lets check if we should just delete the metric from memory.
-			if currentChunk.T0 < metricMinTs {
+			if currentChunk.LastWrite < metricMinTs {
 				return true
 			}
 		}

--- a/metric_tank/chunk.go
+++ b/metric_tank/chunk.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	//"github.com/dgryski/go-tsz"
 	"github.com/raintank/go-tsz"
@@ -14,10 +15,13 @@ type Chunk struct {
 	LastTs    uint32 // last TS seen, not computed or anything
 	NumPoints uint32
 	Saved     bool
+	LastWrite uint32
 }
 
 func NewChunk(t0 uint32) *Chunk {
-	return &Chunk{tsz.New(t0), t0, 0, 0, false}
+	// we must set LastWrite here as well to make sure a new Chunk doesn't get immediately
+	// garbage collected right after creating it, before we can push to it
+	return &Chunk{tsz.New(t0), t0, 0, 0, false, uint32(time.Now().Unix())}
 }
 
 func (c *Chunk) String() string {
@@ -31,5 +35,6 @@ func (c *Chunk) Push(t uint32, v float64) error {
 	c.Series.Push(t, v)
 	c.NumPoints += 1
 	c.LastTs = t
+	c.LastWrite = uint32(time.Now().Unix())
 	return nil
 }


### PR DESCRIPTION
With the prior behavior:
* if you stream in older data, the GC may kick off prematurely
* if you stream in future datapoints and then stop writing, those
  metrics will stay warm extra long.
  Arguably, if GC kicks in after a day, and today is mon, and i write
  data for tue and wed, it may seem sensible to keep the data until thu,
  because by then the data will still be current.  However since this
  would be a forecast metric, this data is only really valuable for the
  future and presumably the dashboards are configured for that as well.

thoughts @woodsaj ?