### PR TITLE
refactor alignRequests() function. issue #89

### DIFF
--- a/metric_tank/aggmetrics.go
+++ b/metric_tank/aggmetrics.go
@@ -100,10 +100,3 @@ func (ms *AggMetrics) GetOrCreate(key string) Metric {
 	ms.Unlock()
 	return m
 }
-
-// returns the minimum span of data we'll always have in RAM (assuming data has been loaded)
-func (ms *AggMetrics) MinSpan() uint32 {
-	ms.RLock()
-	defer ms.RUnlock()
-	return ms.chunkSpan * (ms.numChunks - 1)
-}

--- a/metric_tank/dataprocessor_test.go
+++ b/metric_tank/dataprocessor_test.go
@@ -390,25 +390,6 @@ func TestAlignRequests(t *testing.T) {
 			},
 			nil,
 		},
-		// same but with much lower minDataPoints so now the archives both fit, and the 2nd one can do it with least points and least points from cassandra
-		{
-			[]Req{
-				reqRaw("a", 0, 3600, 20, 800, consolidation.Avg, 10),
-				reqRaw("b", 0, 3600, 20, 800, consolidation.Avg, 10),
-				reqRaw("c", 0, 3600, 20, 800, consolidation.Avg, 10),
-			},
-			2400,
-			[]aggSetting{
-				{60, 600, 2},
-				{120, 600, 1},
-			},
-			[]Req{
-				reqOut("a", 0, 3600, 20, 800, consolidation.Avg, 10, 2, 120, 120, 1),
-				reqOut("b", 0, 3600, 20, 800, consolidation.Avg, 10, 2, 120, 120, 1),
-				reqOut("c", 0, 3600, 20, 800, consolidation.Avg, 10, 2, 120, 120, 1),
-			},
-			nil,
-		},
 		{ // now we request 0-2400, with max datapoints 100. raw can satisfy this from RAM, using some runtime consolidation,
 			// but that's much better than going to cassandra and using any of the other archives
 			[]Req{
@@ -451,7 +432,6 @@ func TestAlignRequests(t *testing.T) {
 		},
 		// same thing as above, but now we set max points to 39, which means at step of 60 is just not going to work
 		// the next best thing (the only one actually) that works is the 1st aggregation at 120 points, for all of em.
-		// but since all data is RAM and we can avoid a cassandra lookup, it'll do it through runtime consolidation
 		{
 			[]Req{
 				reqRaw("a", 0, 2400, 20, 39, consolidation.Avg, 10),
@@ -464,9 +444,9 @@ func TestAlignRequests(t *testing.T) {
 				{600, 600, 2},
 			},
 			[]Req{
-				reqOut("a", 0, 2400, 20, 39, consolidation.Avg, 10, 0, 10, 120, 12),
-				reqOut("b", 0, 2400, 20, 39, consolidation.Avg, 30, 0, 30, 120, 4),
-				reqOut("c", 0, 2400, 20, 39, consolidation.Avg, 60, 0, 60, 120, 2),
+				reqOut("a", 0, 2400, 20, 39, consolidation.Avg, 10, 1, 120, 120, 1),
+				reqOut("b", 0, 2400, 20, 39, consolidation.Avg, 30, 1, 120, 120, 1),
+				reqOut("c", 0, 2400, 20, 39, consolidation.Avg, 60, 1, 120, 120, 1),
 			},
 			nil,
 		},

--- a/metric_tank/dataprocessor_test.go
+++ b/metric_tank/dataprocessor_test.go
@@ -343,19 +343,18 @@ func TestFix(t *testing.T) {
 
 type alignCase struct {
 	reqs        []Req
-	ramSpan     uint32
 	aggSettings []aggSetting
 	outReqs     []Req
 	outErr      error
 }
 
-func reqRaw(key string, from, to, minPoints, maxPoints uint32, consolidator consolidation.Consolidator, rawInterval uint32) Req {
-	req := NewReq(key, from, to, minPoints, maxPoints, consolidator)
+func reqRaw(key string, from, to, maxPoints uint32, consolidator consolidation.Consolidator, rawInterval uint32) Req {
+	req := NewReq(key, from, to, maxPoints, consolidator)
 	req.rawInterval = rawInterval
 	return req
 }
-func reqOut(key string, from, to, minPoints, maxPoints uint32, consolidator consolidation.Consolidator, rawInterval uint32, archive int, archInterval, outInterval, aggNum uint32) Req {
-	req := NewReq(key, from, to, minPoints, maxPoints, consolidator)
+func reqOut(key string, from, to, maxPoints uint32, consolidator consolidation.Consolidator, rawInterval uint32, archive int, archInterval, outInterval, aggNum uint32) Req {
+	req := NewReq(key, from, to, maxPoints, consolidator)
 	req.rawInterval = rawInterval
 	req.archive = archive
 	req.archInterval = archInterval
@@ -374,38 +373,36 @@ func TestAlignRequests(t *testing.T) {
 			// 1 agg 2: 3600/120=30 points in total, none in RAM
 			// only raw has enough points
 			[]Req{
-				reqRaw("a", 0, 3600, 100, 800, consolidation.Avg, 10),
-				reqRaw("b", 0, 3600, 100, 800, consolidation.Avg, 10),
-				reqRaw("c", 0, 3600, 100, 800, consolidation.Avg, 10),
+				reqRaw("a", 0, 3600, 800, consolidation.Avg, 10),
+				reqRaw("b", 0, 3600, 800, consolidation.Avg, 10),
+				reqRaw("c", 0, 3600, 800, consolidation.Avg, 10),
 			},
-			2400,
 			[]aggSetting{
 				{60, 600, 2},
 				{120, 600, 1},
 			},
 			[]Req{
-				reqOut("a", 0, 3600, 100, 800, consolidation.Avg, 10, 0, 10, 10, 1),
-				reqOut("b", 0, 3600, 100, 800, consolidation.Avg, 10, 0, 10, 10, 1),
-				reqOut("c", 0, 3600, 100, 800, consolidation.Avg, 10, 0, 10, 10, 1),
+				reqOut("a", 0, 3600, 800, consolidation.Avg, 10, 0, 10, 10, 1),
+				reqOut("b", 0, 3600, 800, consolidation.Avg, 10, 0, 10, 10, 1),
+				reqOut("c", 0, 3600, 800, consolidation.Avg, 10, 0, 10, 10, 1),
 			},
 			nil,
 		},
 		{ // now we request 0-2400, with max datapoints 100. raw can satisfy this from RAM, using some runtime consolidation,
 			// but that's much better than going to cassandra and using any of the other archives
 			[]Req{
-				reqRaw("a", 0, 2400, 20, 100, consolidation.Avg, 10),
-				reqRaw("b", 0, 2400, 20, 100, consolidation.Avg, 10),
-				reqRaw("c", 0, 2400, 20, 100, consolidation.Avg, 10),
+				reqRaw("a", 0, 2400, 100, consolidation.Avg, 10),
+				reqRaw("b", 0, 2400, 100, consolidation.Avg, 10),
+				reqRaw("c", 0, 2400, 100, consolidation.Avg, 10),
 			},
-			2400,
 			[]aggSetting{
 				{60, 600, 2},
 				{120, 600, 1},
 			},
 			[]Req{
-				reqOut("a", 0, 2400, 20, 100, consolidation.Avg, 10, 0, 10, 30, 3),
-				reqOut("b", 0, 2400, 20, 100, consolidation.Avg, 10, 0, 10, 30, 3),
-				reqOut("c", 0, 2400, 20, 100, consolidation.Avg, 10, 0, 10, 30, 3),
+				reqOut("a", 0, 2400, 100, consolidation.Avg, 10, 0, 10, 30, 3),
+				reqOut("b", 0, 2400, 100, consolidation.Avg, 10, 0, 10, 30, 3),
+				reqOut("c", 0, 2400, 100, consolidation.Avg, 10, 0, 10, 30, 3),
 			},
 			nil,
 		},
@@ -414,19 +411,18 @@ func TestAlignRequests(t *testing.T) {
 		// so runtime consolidation is needed, we'll get 40 points for each metric
 		{
 			[]Req{
-				reqRaw("a", 0, 2400, 20, 100, consolidation.Avg, 10),
-				reqRaw("b", 0, 2400, 20, 100, consolidation.Avg, 30),
-				reqRaw("c", 0, 2400, 20, 100, consolidation.Avg, 60),
+				reqRaw("a", 0, 2400, 100, consolidation.Avg, 10),
+				reqRaw("b", 0, 2400, 100, consolidation.Avg, 30),
+				reqRaw("c", 0, 2400, 100, consolidation.Avg, 60),
 			},
-			2400,
 			[]aggSetting{
 				{120, 600, 2},
 				{600, 600, 2},
 			},
 			[]Req{
-				reqOut("a", 0, 2400, 20, 100, consolidation.Avg, 10, 0, 10, 60, 6),
-				reqOut("b", 0, 2400, 20, 100, consolidation.Avg, 30, 0, 30, 60, 2),
-				reqOut("c", 0, 2400, 20, 100, consolidation.Avg, 60, 0, 60, 60, 1),
+				reqOut("a", 0, 2400, 100, consolidation.Avg, 10, 0, 10, 60, 6),
+				reqOut("b", 0, 2400, 100, consolidation.Avg, 30, 0, 30, 60, 2),
+				reqOut("c", 0, 2400, 100, consolidation.Avg, 60, 0, 60, 60, 1),
 			},
 			nil,
 		},
@@ -434,19 +430,18 @@ func TestAlignRequests(t *testing.T) {
 		// the next best thing (the only one actually) that works is the 1st aggregation at 120 points, for all of em.
 		{
 			[]Req{
-				reqRaw("a", 0, 2400, 20, 39, consolidation.Avg, 10),
-				reqRaw("b", 0, 2400, 20, 39, consolidation.Avg, 30),
-				reqRaw("c", 0, 2400, 20, 39, consolidation.Avg, 60),
+				reqRaw("a", 0, 2400, 39, consolidation.Avg, 10),
+				reqRaw("b", 0, 2400, 39, consolidation.Avg, 30),
+				reqRaw("c", 0, 2400, 39, consolidation.Avg, 60),
 			},
-			2400,
 			[]aggSetting{
 				{120, 600, 2},
 				{600, 600, 2},
 			},
 			[]Req{
-				reqOut("a", 0, 2400, 20, 39, consolidation.Avg, 10, 1, 120, 120, 1),
-				reqOut("b", 0, 2400, 20, 39, consolidation.Avg, 30, 1, 120, 120, 1),
-				reqOut("c", 0, 2400, 20, 39, consolidation.Avg, 60, 1, 120, 120, 1),
+				reqOut("a", 0, 2400, 39, consolidation.Avg, 10, 1, 120, 120, 1),
+				reqOut("b", 0, 2400, 39, consolidation.Avg, 30, 1, 120, 120, 1),
+				reqOut("c", 0, 2400, 39, consolidation.Avg, 60, 1, 120, 120, 1),
 			},
 			nil,
 		},
@@ -454,20 +449,19 @@ func TestAlignRequests(t *testing.T) {
 		// this should come out of RAM
 		{
 			[]Req{
-				reqRaw("a", 0, 3600*3, 100, 1000, consolidation.Avg, 10),
-				reqRaw("b", 0, 3600*3, 100, 1000, consolidation.Avg, 30),
-				reqRaw("c", 0, 3600*3, 100, 1000, consolidation.Avg, 60),
+				reqRaw("a", 0, 3600*3, 1000, consolidation.Avg, 10),
+				reqRaw("b", 0, 3600*3, 1000, consolidation.Avg, 30),
+				reqRaw("c", 0, 3600*3, 1000, consolidation.Avg, 60),
 			},
-			600 * 36, // retain in ram 36 chunks of 10min, i.e. 6h worth of data
 			[]aggSetting{
 				{600, 21600, 1}, // aggregations stored in 6h chunks
 				{7200, 21600, 1},
 				{21600, 21600, 1},
 			},
 			[]Req{
-				reqOut("a", 0, 3600*3, 100, 1000, consolidation.Avg, 10, 0, 10, 60, 6),
-				reqOut("b", 0, 3600*3, 100, 1000, consolidation.Avg, 30, 0, 30, 60, 2),
-				reqOut("c", 0, 3600*3, 100, 1000, consolidation.Avg, 60, 0, 60, 60, 1),
+				reqOut("a", 0, 3600*3, 1000, consolidation.Avg, 10, 0, 10, 60, 6),
+				reqOut("b", 0, 3600*3, 1000, consolidation.Avg, 30, 0, 30, 60, 2),
+				reqOut("c", 0, 3600*3, 1000, consolidation.Avg, 60, 0, 60, 60, 1),
 			},
 			nil,
 		},
@@ -475,20 +469,19 @@ func TestAlignRequests(t *testing.T) {
 		// this should come out of RAM
 		{
 			[]Req{
-				reqRaw("a", 0, 3600*6, 100, 1000, consolidation.Avg, 10),
-				reqRaw("b", 0, 3600*6, 100, 1000, consolidation.Avg, 30),
-				reqRaw("c", 0, 3600*6, 100, 1000, consolidation.Avg, 60),
+				reqRaw("a", 0, 3600*6, 1000, consolidation.Avg, 10),
+				reqRaw("b", 0, 3600*6, 1000, consolidation.Avg, 30),
+				reqRaw("c", 0, 3600*6, 1000, consolidation.Avg, 60),
 			},
-			600 * 36, // retain in ram 36 chunks of 10min, i.e. 6h worth of data
 			[]aggSetting{
 				{600, 21600, 1}, // aggregations stored in 6h chunks
 				{7200, 21600, 1},
 				{21600, 21600, 1},
 			},
 			[]Req{
-				reqOut("a", 0, 3600*6, 100, 1000, consolidation.Avg, 10, 0, 10, 60, 6),
-				reqOut("b", 0, 3600*6, 100, 1000, consolidation.Avg, 30, 0, 30, 60, 2),
-				reqOut("c", 0, 3600*6, 100, 1000, consolidation.Avg, 60, 0, 60, 60, 1),
+				reqOut("a", 0, 3600*6, 1000, consolidation.Avg, 10, 0, 10, 60, 6),
+				reqOut("b", 0, 3600*6, 1000, consolidation.Avg, 30, 0, 30, 60, 2),
+				reqOut("c", 0, 3600*6, 1000, consolidation.Avg, 60, 0, 60, 60, 1),
 			},
 			nil,
 		},
@@ -496,20 +489,19 @@ func TestAlignRequests(t *testing.T) {
 		// this should come out of raw archive, mostly out of ram
 		{
 			[]Req{
-				reqRaw("a", 0, 3600*9, 100, 1000, consolidation.Avg, 10),
-				reqRaw("b", 0, 3600*9, 100, 1000, consolidation.Avg, 30),
-				reqRaw("c", 0, 3600*9, 100, 1000, consolidation.Avg, 60),
+				reqRaw("a", 0, 3600*9, 1000, consolidation.Avg, 10),
+				reqRaw("b", 0, 3600*9, 1000, consolidation.Avg, 30),
+				reqRaw("c", 0, 3600*9, 1000, consolidation.Avg, 60),
 			},
-			600 * 36, // retain in ram 36 chunks of 10min, i.e. 6h worth of data
 			[]aggSetting{
 				{600, 21600, 1}, // aggregations stored in 6h chunks
 				{7200, 21600, 1},
 				{21600, 21600, 1},
 			},
 			[]Req{
-				reqOut("a", 0, 3600*9, 100, 1000, consolidation.Avg, 10, 0, 10, 60, 6),
-				reqOut("b", 0, 3600*9, 100, 1000, consolidation.Avg, 30, 0, 30, 60, 2),
-				reqOut("c", 0, 3600*9, 100, 1000, consolidation.Avg, 60, 0, 60, 60, 1),
+				reqOut("a", 0, 3600*9, 1000, consolidation.Avg, 10, 0, 10, 60, 6),
+				reqOut("b", 0, 3600*9, 1000, consolidation.Avg, 30, 0, 30, 60, 2),
+				reqOut("c", 0, 3600*9, 1000, consolidation.Avg, 60, 0, 60, 60, 1),
 			},
 			nil,
 		},
@@ -519,20 +511,19 @@ func TestAlignRequests(t *testing.T) {
 		// first agg at 600s step can return 144 points without runtime consolidation, needing 24h of data from c* at 600s, which is the better deal
 		{
 			[]Req{
-				reqRaw("a", 0, 3600*24, 100, 1000, consolidation.Avg, 10),
-				reqRaw("b", 0, 3600*24, 100, 1000, consolidation.Avg, 30),
-				reqRaw("c", 0, 3600*24, 100, 1000, consolidation.Avg, 60),
+				reqRaw("a", 0, 3600*24, 1000, consolidation.Avg, 10),
+				reqRaw("b", 0, 3600*24, 1000, consolidation.Avg, 30),
+				reqRaw("c", 0, 3600*24, 1000, consolidation.Avg, 60),
 			},
-			600 * 36, // retain in ram 36 chunks of 10min, i.e. 6h worth of data
 			[]aggSetting{
 				{600, 21600, 1}, // aggregations stored in 6h chunks
 				{7200, 21600, 1},
 				{21600, 21600, 1},
 			},
 			[]Req{
-				reqOut("a", 0, 3600*24, 100, 1000, consolidation.Avg, 10, 1, 600, 600, 1),
-				reqOut("b", 0, 3600*24, 100, 1000, consolidation.Avg, 30, 1, 600, 600, 1),
-				reqOut("c", 0, 3600*24, 100, 1000, consolidation.Avg, 60, 1, 600, 600, 1),
+				reqOut("a", 0, 3600*24, 1000, consolidation.Avg, 10, 1, 600, 600, 1),
+				reqOut("b", 0, 3600*24, 1000, consolidation.Avg, 30, 1, 600, 600, 1),
+				reqOut("c", 0, 3600*24, 1000, consolidation.Avg, 60, 1, 600, 600, 1),
 			},
 			nil,
 		},
@@ -542,26 +533,25 @@ func TestAlignRequests(t *testing.T) {
 		// 2nd archive can do it in 3600*24*7 / 7200 = 84 points, but that's not enough to satisfy mindatapoints, so we should use first archive + runtime consol
 		{
 			[]Req{
-				reqRaw("a", 0, 3600*24*7, 100, 1000, consolidation.Avg, 10),
-				reqRaw("b", 0, 3600*24*7, 100, 1000, consolidation.Avg, 30),
-				reqRaw("c", 0, 3600*24*7, 100, 1000, consolidation.Avg, 60),
+				reqRaw("a", 0, 3600*24*7, 1000, consolidation.Avg, 10),
+				reqRaw("b", 0, 3600*24*7, 1000, consolidation.Avg, 30),
+				reqRaw("c", 0, 3600*24*7, 1000, consolidation.Avg, 60),
 			},
-			600 * 36, // retain in ram 36 chunks of 10min, i.e. 6h worth of data
 			[]aggSetting{
 				{600, 21600, 1}, // aggregations stored in 6h chunks
 				{7200, 21600, 1},
 				{21600, 21600, 1},
 			},
 			[]Req{
-				reqOut("a", 0, 3600*24*7, 100, 1000, consolidation.Avg, 10, 1, 600, 1200, 2),
-				reqOut("b", 0, 3600*24*7, 100, 1000, consolidation.Avg, 30, 1, 600, 1200, 2),
-				reqOut("c", 0, 3600*24*7, 100, 1000, consolidation.Avg, 60, 1, 600, 1200, 2),
+				reqOut("a", 0, 3600*24*7, 1000, consolidation.Avg, 10, 1, 600, 1200, 2),
+				reqOut("b", 0, 3600*24*7, 1000, consolidation.Avg, 30, 1, 600, 1200, 2),
+				reqOut("c", 0, 3600*24*7, 1000, consolidation.Avg, 60, 1, 600, 1200, 2),
 			},
 			nil,
 		},
 	}
 	for i, ac := range input {
-		out, err := alignRequests(ac.reqs, ac.ramSpan, ac.aggSettings)
+		out, err := alignRequests(ac.reqs, ac.aggSettings)
 		if err != ac.outErr {
 			t.Fatalf("different err value for testcase %d  expected: %v, got: %v", i, ac.outErr, err)
 		}
@@ -582,9 +572,9 @@ var result []Req
 func BenchmarkAlignRequests(b *testing.B) {
 	var res []Req
 	reqs := []Req{
-		reqRaw("a", 0, 3600*24*7, 100, 1000, consolidation.Avg, 10),
-		reqRaw("b", 0, 3600*24*7, 100, 1000, consolidation.Avg, 30),
-		reqRaw("c", 0, 3600*24*7, 100, 1000, consolidation.Avg, 60),
+		reqRaw("a", 0, 3600*24*7, 1000, consolidation.Avg, 10),
+		reqRaw("b", 0, 3600*24*7, 1000, consolidation.Avg, 30),
+		reqRaw("c", 0, 3600*24*7, 1000, consolidation.Avg, 60),
 	}
 	aggSettings := []aggSetting{
 		{600, 21600, 1},
@@ -593,7 +583,7 @@ func BenchmarkAlignRequests(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n++ {
-		res, _ = alignRequests(reqs, 21600, aggSettings)
+		res, _ = alignRequests(reqs, aggSettings)
 	}
 	result = res
 }

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -45,7 +45,6 @@ func Get(w http.ResponseWriter, req *http.Request, metaCache *MetaCache, aggSett
 	log.Debug(fmt.Sprintf("http.Get(): INCOMING REQ. targets: %q, maxDataPoints: %q", values.Get("target"), values.Get("maxDataPoints")))
 
 	maxDataPoints := uint32(800)
-	minDataPoints := uint32(1)
 	maxDataPointsStr := values.Get("maxDataPoints")
 	var err error
 	if maxDataPointsStr != "" {
@@ -55,7 +54,6 @@ func Get(w http.ResponseWriter, req *http.Request, metaCache *MetaCache, aggSett
 			return
 		}
 		maxDataPoints = uint32(tmp)
-		minDataPoints = maxDataPoints / 10
 	}
 
 	targets, ok := values["target"]
@@ -129,7 +127,7 @@ func Get(w http.ResponseWriter, req *http.Request, metaCache *MetaCache, aggSett
 			http.Error(w, "unrecognized consolidation function", http.StatusBadRequest)
 			return
 		}
-		req := NewReq(id, fromUnix, toUnix, minDataPoints, maxDataPoints, consolidator)
+		req := NewReq(id, fromUnix, toUnix, maxDataPoints, consolidator)
 		reqs[i] = req
 	}
 	err = findMetricsForRequests(reqs, metaCache)
@@ -137,7 +135,7 @@ func Get(w http.ResponseWriter, req *http.Request, metaCache *MetaCache, aggSett
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	reqs, err = alignRequests(reqs, metrics.MinSpan(), aggSettings)
+	reqs, err = alignRequests(reqs, aggSettings)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/metric_tank/query_engine.go
+++ b/metric_tank/query_engine.go
@@ -24,19 +24,6 @@ func (a archives) Len() int           { return len(a) }
 func (a archives) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a archives) Less(i, j int) bool { return a[i].interval < a[j].interval }
 
-// provides exact execution details for each request, as well as a cost of executing everything
-type solution struct {
-	reqs []Req
-	cost uint32
-}
-
-func NewSolution() *solution {
-	return &solution{
-		make([]Req, 0),
-		0,
-	}
-}
-
 func findMetricsForRequests(reqs []Req, metaCache *MetaCache) error {
 	for i := range reqs {
 		err := metaCache.UpdateReq(&reqs[i])
@@ -50,8 +37,8 @@ func findMetricsForRequests(reqs []Req, metaCache *MetaCache) error {
 // updates the requests with all details for fetching, making sure all metrics are in the same, optimal interval
 // luckily, all metrics still use the same aggSettings, making this a bit simpler
 // for all requests, sets archive, numPoints, interval (and rawInterval as a side effect)
-// note: it is assumed that all requests have the same from, to, minDataPoints and maxdatapoints!
-func alignRequests(reqs []Req, ramSpan uint32, aggSettings []aggSetting) ([]Req, error) {
+// note: it is assumed that all requests have the same from, to and maxdatapoints!
+func alignRequests(reqs []Req, aggSettings []aggSetting) ([]Req, error) {
 
 	// model all the archives for each requested metric
 	// the 0th archive is always the raw series, with highest res (lowest interval)

--- a/metric_tank/query_engine.go
+++ b/metric_tank/query_engine.go
@@ -1,64 +1,21 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"github.com/grafana/grafana/pkg/log"
-	"math"
 	"sort"
 )
 
 // represents a data "archive", i.e. the raw one, or an aggregated series
 type archive struct {
-	title    string
-	key      int // 0 for raw, 1 for first aggregation, etc.
-	interval uint32
-	ramSpan  uint32 // what's the span we have in memory
-	comment  string
-	cost     uint32 // computed when solving for best requests
+	title      string
+	interval   uint32
+	pointCount uint32
+	comment    string
 }
 
 func (b archive) String() string {
-	return fmt.Sprintf("<archive %d: %s> int:%d, ram:%d, cost: %d, comment: %s", b.key, b.title, b.interval, b.ramSpan, b.cost, b.comment)
-}
-
-// returns cost, aggNum and whether possible at all
-// by comparing the archive with the requested output interval of the req.
-func (b *archive) costFor(r Req) (uint32, uint32, bool) {
-	b.cost = 0
-	timespan := r.to - r.from
-
-	// settings assuming no runtime consolidation
-	finalPoints := timespan / b.interval
-	aggNum := uint32(1)
-
-	if b.interval > r.outInterval {
-		// this archive can't be used at all.
-		return 0, 0, false
-	} else if b.interval < r.outInterval {
-		if r.outInterval%b.interval != 0 {
-			// this archive can't be aggregated to match the requested interval
-			return 0, 0, false
-		}
-		aggNum = r.outInterval / b.interval
-		// add the cost for each point that should be runtime-consolidated away
-		finalPoints = finalPoints / aggNum
-		b.cost += ((aggNum - 1) * finalPoints) * 10
-	}
-	if finalPoints > r.maxPoints || finalPoints < r.minPoints {
-		b.cost = 0
-		return 0, 0, false
-	}
-
-	// add cost for data that should be fetched from storage
-	// TODO this doesn't take into account from-to, it assumes to=now.
-	if b.ramSpan < timespan {
-		b.cost += (timespan - b.ramSpan) / b.interval * 500
-	}
-	// add cost for just having a lot of points in output
-	b.cost += finalPoints
-
-	return b.cost, aggNum, true
+	return fmt.Sprintf("<archive %s> int:%d, comment: %s", b.title, b.interval, b.comment)
 }
 
 type archives []archive
@@ -100,114 +57,141 @@ func alignRequests(reqs []Req, ramSpan uint32, aggSettings []aggSetting) ([]Req,
 	// the 0th archive is always the raw series, with highest res (lowest interval)
 	aggs := aggSettingsSpanAsc(aggSettings)
 	sort.Sort(aggs)
-	allarchives := make([][]archive, len(reqs))
-	for i, req := range reqs {
-		allarchives[i] = make([]archive, len(aggs)+1)
 
-		// model the first archive, the raw storage
-		allarchives[i][0] = archive{"raw ", 0, req.rawInterval, ramSpan, "", 0}
+	options := make([]archive, len(aggs)+1)
 
-		// now model the archives we get from the aggregations
-		for j, agg := range aggs {
-			ramSpan := agg.chunkSpan * (agg.numChunks - 1)
-			allarchives[i][j+1] = archive{fmt.Sprintf("agg %d", j), j + 1, agg.span, ramSpan, "", 0}
+	minInterval := uint32(0)
+	rawIntervals := make(map[uint32]bool)
+	for _, req := range reqs {
+		if minInterval == 0 || minInterval > req.rawInterval {
+			minInterval = req.rawInterval
+		}
+		rawIntervals[req.rawInterval] = true
+	}
+	tsRange := (reqs[0].to - reqs[0].from)
+
+	options[0] = archive{"raw", minInterval, tsRange / minInterval, ""}
+	// now model the archives we get from the aggregations
+	for j, agg := range aggs {
+		options[j+1] = archive{fmt.Sprintf("agg %d", j), agg.span, tsRange / agg.span, ""}
+	}
+
+	// find the first option with a pointCount < maxDataPoints
+	selected := len(options) - 1
+	for i, opt := range options {
+		if opt.pointCount < reqs[0].maxPoints {
+			selected = i
+			break
 		}
 	}
 
-	// now we know for each metric all the available archives.
-	// first find the highest raw interval amongst the metrics
-	// this is effectively the lowest interval that can be returned by all of the requested metrics
-	// some may need to do runtime consolidation for that to happen though
-	// eg for
-	// 10 raw, 600, 7200, 21600
-	// 30 raw, 600, 7200, 21600
-	// 60 raw, 600, 7200, 21600
-	// would return 60
-	// an optimization to avoid intervals that for many of the metrics would have to be runtime consolidated
-	// can be added later.
-	highestLowestInterval := uint32(0)
-	for _, archives := range allarchives {
-		if archives[0].interval > highestLowestInterval {
-			highestLowestInterval = archives[0].interval
+	/*
+	   do a quick calculation of the ratio between pointCount and maxDatapoints of
+	   the selected option, and the option before that.  eg. with a time range of 1hour,
+	   our pointCounts for each option are:
+	   10s   | 360
+	   600s  | 6
+	   7200s | 0
+
+	   if maxPoints is 100, then selected will be 1, our 600s rollups.
+	   We then calculate the ratio between maxPoints and our
+	   selected pointCount "6" and the previous option "360".
+	   belowMaxDataPointsRatio  =  16  #(100/6)
+	   aboveMaxDataPointsRatio  =  3   #(360/100)
+
+	   As the maxDataPoint requested is much closer to 360 then it is to 6,
+	   we will use 360 and do runtime consolidation.
+	*/
+	runTimeConsolidate := false
+	if selected > 0 {
+		belowMaxDataPointsRatio := float64(reqs[0].maxPoints) / float64(options[selected].pointCount)
+		aboveMaxDataPointsRatio := float64(options[selected-1].pointCount) / float64(reqs[0].maxPoints)
+
+		if aboveMaxDataPointsRatio < belowMaxDataPointsRatio {
+			selected--
+			runTimeConsolidate = true
 		}
 	}
 
-	// now let's find the best interval based on what all the metrics can return.
-	// solutions are scored based on 3 factors, in order of importance:
-	// 1) the more we can fulfill by using data in RAM as opposed to external storage, the better
-	// 2) least amount of runtime consolidation possible.
-	// 3) least amount of points needed, but still satisfying minDataPoints
+	chosenInterval := options[selected].interval
 
-	// note that for some metrics, highestLowestInterval may not occur in any of the archives natively. not raw, not in the aggregations.
-	// so the possible output intervals are all sensible intervals between
-	// highestLowestInterval (which either matches, or is larger than the raw archive) and
-	// the maximum interval possible given minDataPoints.
-	low := highestLowestInterval
-	interval := (reqs[0].to - reqs[0].from)
-	high := interval / reqs[0].minPoints
-	if interval%reqs[0].minPoints != 0 {
-		high += 1
-	}
-	outputIntervals := make([]uint32, 0)
-	for i := low; i < high+10; i += 10 {
-		outputIntervals = append(outputIntervals, i)
+	// if we are using raw metrics, we need to find an interval that all request intervals work with.
+	if selected == 0 && len(rawIntervals) > 1 {
+		runTimeConsolidate = true
+		var keys []int
+		for k := range rawIntervals {
+			keys = append(keys, int(k))
+		}
+		sort.Ints(keys)
+		chosenInterval = uint32(keys[0])
+		for i := 1; i < len(keys); i++ {
+			var a, b uint32
+			if uint32(keys[i]) > chosenInterval {
+				a = uint32(keys[i])
+				b = chosenInterval
+			} else {
+				a = chosenInterval
+				b = uint32(keys[i])
+			}
+			r := a % b
+			if r != 0 {
+				for j := uint32(2); j <= b; j++ {
+					if (j*a)%b == 0 {
+						chosenInterval = j * a
+						break
+					}
+				}
+			} else {
+
+				chosenInterval = uint32(a)
+			}
+			options[0].pointCount = tsRange / chosenInterval
+			options[0].interval = chosenInterval
+		}
+		//make sure that the calculated interval is not greater then the interval of the fist rollup.
+		if len(options) > 1 && chosenInterval > options[1].interval {
+			selected = 1
+			chosenInterval = options[1].interval
+		}
 	}
 
-	// there's a solution for each input interval (hopefully)
-	// each solution is a set of requests to satisfy all targets for said interval, along with associated cost to satisfy all those requests
-	solutions := make([]*solution, 0, len(outputIntervals))
-INTERVALS:
-	for _, interval := range outputIntervals {
-		s := NewSolution()
-		for j, req := range reqs {
-			// for this given req and interval, find the archive with the lowest cost.
-			req.outInterval = interval
-			lowestCost := uint32(math.MaxUint32)
-			for _, archive := range allarchives[j] {
-				cost, aggNum, possible := archive.costFor(req)
-				if possible && cost < lowestCost {
-					lowestCost = cost
-					req.archive = archive.key
-					req.archInterval = archive.interval
-					req.aggNum = aggNum
+	options[selected].comment = "<-- chosen"
+	for _, archive := range options {
+		log.Debug("%-6s %-6d %-6d %s", archive.title, archive.interval, tsRange/archive.interval, archive.comment)
+	}
+
+	/* we now just need to update the archiveInterval, outInterval and aggNum of each req.
+	   archInterval uint32 // the interval corresponding to the archive we'll fetch
+	   outInterval  uint32 // the interval of the output data, after any runtime consolidation
+	   aggNum       uint32 // how many points to consolidate together at runtime, after fetching from the archive
+	*/
+	for i, _ := range reqs {
+		req := &reqs[i]
+		req.archive = selected
+		req.archInterval = options[selected].interval
+		req.outInterval = chosenInterval
+		aggNum := uint32(1)
+		if runTimeConsolidate {
+			ptCount := options[selected].pointCount
+
+			aggNum = ptCount / req.maxPoints
+			if ptCount%req.maxPoints != 0 {
+				aggNum++
+			}
+			if selected == 0 {
+				// Handle RAW interval
+				req.archInterval = req.rawInterval
+
+				// each request can have a different rawInterval. So the aggNum is vairable.
+				if chosenInterval != req.rawInterval {
+					aggNum = aggNum * (chosenInterval / req.rawInterval)
 				}
 			}
-			// this metric has no archives to satisfy this interval at all
-			// so this interval has no solution
-			if lowestCost == uint32(math.MaxUint32) {
-				continue INTERVALS
-			} else {
-				s.cost += lowestCost
-				s.reqs = append(s.reqs, req)
-			}
+
+			req.outInterval = req.archInterval * aggNum
 		}
-		// we're still here, so we've built a complete solution that can satisfy each request for a given total cost.
-		solutions = append(solutions, s)
-	}
-	if len(solutions) == 0 {
-		return nil, errors.New("minDataPoints/maxDataPoints cannot be honored with the series requested")
-	}
-	lowestCost := uint32(math.MaxUint32)
-	bestSolution := -1
-	for i, solution := range solutions {
-		if solution.cost < lowestCost {
-			lowestCost = solution.cost
-			bestSolution = i
-		}
-	}
-	solution := solutions[bestSolution]
 
-	for i, req := range solution.reqs {
-		allarchives[i][solution.reqs[i].archive].comment = "<-- chosen"
-
-		// note, it should always be safe to dynamically switch on/off consolidation based on how well our data stacks up against the request
-		// i.e. whether your data got consolidated or not, it should be pretty equivalent.
-		// for that reason, stdev should not be done as a consolidation. but sos is still useful for when we explicitly (and always, not optionally) want the stdev.
-
-		for _, archive := range allarchives[i] {
-			log.Debug("%-6s %-6d %-6d %s", archive.title, archive.interval, (req.to-req.from)/archive.interval, archive.comment)
-		}
+		req.aggNum = aggNum
 	}
-	return solution.reqs, nil
-
+	return reqs, nil
 }

--- a/metric_tank/query_engine.go
+++ b/metric_tank/query_engine.go
@@ -136,7 +136,7 @@ func alignRequests(reqs []Req, aggSettings []aggSetting) ([]Req, error) {
 			options[0].interval = chosenInterval
 		}
 		//make sure that the calculated interval is not greater then the interval of the fist rollup.
-		if len(options) > 1 && chosenInterval > options[1].interval {
+		if len(options) > 1 && chosenInterval >= options[1].interval {
 			selected = 1
 			chosenInterval = options[1].interval
 		}

--- a/metric_tank/req.go
+++ b/metric_tank/req.go
@@ -10,7 +10,6 @@ type Req struct {
 	key          string
 	from         uint32
 	to           uint32
-	minPoints    uint32
 	maxPoints    uint32
 	consolidator consolidation.Consolidator
 
@@ -22,12 +21,11 @@ type Req struct {
 	aggNum       uint32 // how many points to consolidate together at runtime, after fetching from the archive
 }
 
-func NewReq(key string, from, to, minPoints, maxPoints uint32, consolidator consolidation.Consolidator) Req {
+func NewReq(key string, from, to, maxPoints uint32, consolidator consolidation.Consolidator) Req {
 	return Req{
 		key,
 		from,
 		to,
-		minPoints,
 		maxPoints,
 		consolidator,
 		-1, // this is supposed to be updated still!
@@ -39,10 +37,10 @@ func NewReq(key string, from, to, minPoints, maxPoints uint32, consolidator cons
 }
 
 func (r Req) String() string {
-	return fmt.Sprintf("%s %d - %d (%s - %s) span:%ds. %d <= points <= %d. %s", r.key, r.from, r.to, TS(r.from), TS(r.to), r.to-r.from-1, r.minPoints, r.maxPoints, r.consolidator)
+	return fmt.Sprintf("%s %d - %d (%s - %s) span:%ds. points <= %d. %s", r.key, r.from, r.to, TS(r.from), TS(r.to), r.to-r.from-1, r.maxPoints, r.consolidator)
 }
 
 func (r Req) DebugString() string {
-	return fmt.Sprintf("%s %d - %d . %d <= points <= %d. %s - archive %d, rawInt %d, archInt %d, outInt %d, aggNum %d",
-		r.key, r.from, r.to, r.minPoints, r.maxPoints, r.consolidator, r.archive, r.rawInterval, r.archInterval, r.outInterval, r.aggNum)
+	return fmt.Sprintf("%s %d - %d . points <= %d. %s - archive %d, rawInt %d, archInt %d, outInt %d, aggNum %d",
+		r.key, r.from, r.to, r.maxPoints, r.consolidator, r.archive, r.rawInterval, r.archInterval, r.outInterval, r.aggNum)
 }


### PR DESCRIPTION
The logic in alignRequests was far too complex. Though it had
some great capabilities around prefencing in-memory data over data
in Cassandra, it failed to address common use cases.