### PR TITLE
Refactor how chunks are persisted.

### DIFF
--- a/metric_tank/aggmetric_test.go
+++ b/metric_tank/aggmetric_test.go
@@ -156,7 +156,7 @@ func BenchmarkAggMetrics1000Metrics1Day(b *testing.B) {
 	numChunks := uint32(5)
 	chunkMaxStale := uint32(3600)
 	metricMaxStale := uint32(21600)
-	maxDirtyChunks := uint32(1)
+	ttl := uint32(84600)
 	aggSettings := []aggSetting{
 		{
 			span:      uint32(300),
@@ -170,7 +170,7 @@ func BenchmarkAggMetrics1000Metrics1Day(b *testing.B) {
 		keys[i] = fmt.Sprintf("hello.this.is.a.test.key.%d", i)
 	}
 
-	metrics := NewAggMetrics(chunkSpan, numChunks, chunkMaxStale, metricMaxStale, maxDirtyChunks, aggSettings)
+	metrics := NewAggMetrics(chunkSpan, numChunks, chunkMaxStale, metricMaxStale, ttl, aggSettings)
 
 	maxT := 3600 * 24 * uint32(b.N) // b.N in days
 	for t := uint32(1); t < maxT; t += 10 {

--- a/metric_tank/aggmetrics.go
+++ b/metric_tank/aggmetrics.go
@@ -15,7 +15,7 @@ type AggMetrics struct {
 	aggSettings    []aggSetting // for now we apply the same settings to all AggMetrics. later we may want to have different settings.
 	chunkMaxStale  uint32
 	metricMaxStale uint32
-	maxDirtyChunks uint32
+	ttl            uint32
 }
 
 var totalPoints chan int
@@ -25,7 +25,7 @@ func init() {
 	totalPoints = make(chan int, 1000)
 }
 
-func NewAggMetrics(chunkSpan, numChunks, chunkMaxStale, metricMaxStale uint32, maxDirtyChunks uint32, aggSettings []aggSetting) *AggMetrics {
+func NewAggMetrics(chunkSpan, numChunks, chunkMaxStale, metricMaxStale uint32, ttl uint32, aggSettings []aggSetting) *AggMetrics {
 	ms := AggMetrics{
 		Metrics:        make(map[string]*AggMetric),
 		chunkSpan:      chunkSpan,
@@ -33,7 +33,7 @@ func NewAggMetrics(chunkSpan, numChunks, chunkMaxStale, metricMaxStale uint32, m
 		aggSettings:    aggSettings,
 		chunkMaxStale:  chunkMaxStale,
 		metricMaxStale: metricMaxStale,
-		maxDirtyChunks: maxDirtyChunks,
+		ttl:            ttl,
 	}
 
 	go ms.stats()
@@ -94,7 +94,7 @@ func (ms *AggMetrics) GetOrCreate(key string) Metric {
 	ms.Lock()
 	m, ok := ms.Metrics[key]
 	if !ok {
-		m = NewAggMetric(key, ms.chunkSpan, ms.numChunks, ms.maxDirtyChunks, ms.aggSettings...)
+		m = NewAggMetric(key, ms.chunkSpan, ms.numChunks, ms.ttl, ms.aggSettings...)
 		ms.Metrics[key] = m
 	}
 	ms.Unlock()

--- a/metric_tank/aggregator.go
+++ b/metric_tank/aggregator.go
@@ -36,17 +36,17 @@ type Aggregator struct {
 	lstMetric       *AggMetric
 }
 
-func NewAggregator(key string, aggSpan, aggChunkSpan, aggNumChunks uint32, maxDirtyChunks uint32) *Aggregator {
+func NewAggregator(key string, aggSpan, aggChunkSpan, aggNumChunks uint32, ttl uint32) *Aggregator {
 	return &Aggregator{
 		key:       key,
 		span:      aggSpan,
 		agg:       NewAggregation(),
-		minMetric: NewAggMetric(fmt.Sprintf("%s_min_%d", key, aggSpan), aggChunkSpan, aggNumChunks, maxDirtyChunks),
-		maxMetric: NewAggMetric(fmt.Sprintf("%s_max_%d", key, aggSpan), aggChunkSpan, aggNumChunks, maxDirtyChunks),
-		sosMetric: NewAggMetric(fmt.Sprintf("%s_sos_%d", key, aggSpan), aggChunkSpan, aggNumChunks, maxDirtyChunks),
-		sumMetric: NewAggMetric(fmt.Sprintf("%s_sum_%d", key, aggSpan), aggChunkSpan, aggNumChunks, maxDirtyChunks),
-		cntMetric: NewAggMetric(fmt.Sprintf("%s_cnt_%d", key, aggSpan), aggChunkSpan, aggNumChunks, maxDirtyChunks),
-		lstMetric: NewAggMetric(fmt.Sprintf("%s_lst_%d", key, aggSpan), aggChunkSpan, aggNumChunks, maxDirtyChunks),
+		minMetric: NewAggMetric(fmt.Sprintf("%s_min_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		maxMetric: NewAggMetric(fmt.Sprintf("%s_max_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		sosMetric: NewAggMetric(fmt.Sprintf("%s_sos_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		sumMetric: NewAggMetric(fmt.Sprintf("%s_sum_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		cntMetric: NewAggMetric(fmt.Sprintf("%s_cnt_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
+		lstMetric: NewAggMetric(fmt.Sprintf("%s_lst_%d", key, aggSpan), aggChunkSpan, aggNumChunks, ttl),
 	}
 }
 func (agg *Aggregator) flush() string {

--- a/metric_tank/aggregator_test.go
+++ b/metric_tank/aggregator_test.go
@@ -60,13 +60,13 @@ func TestAggregator(t *testing.T) {
 		}
 		clusterStatus.Set(false)
 	}
-	agg := NewAggregator("test", 60, 120, 10, 10)
+	agg := NewAggregator("test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	expected := []Point{}
 	compare("simple-min-unfinished", agg.minMetric, expected)
 
-	agg = NewAggregator("test", 60, 120, 10, 10)
+	agg = NewAggregator("test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(130, 130)
@@ -75,7 +75,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block", agg.minMetric, expected)
 
-	agg = NewAggregator("test", 60, 120, 10, 10)
+	agg = NewAggregator("test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(120, 4)
@@ -84,7 +84,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-one-block-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator("test", 60, 120, 10, 10)
+	agg = NewAggregator("test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(150, 1.123)
@@ -95,7 +95,7 @@ func TestAggregator(t *testing.T) {
 	}
 	compare("simple-min-two-blocks-done-cause-last-point-just-right", agg.minMetric, expected)
 
-	agg = NewAggregator("test", 60, 120, 10, 10)
+	agg = NewAggregator("test", 60, 120, 10, 86400)
 	agg.Add(100, 123.4)
 	agg.Add(110, 5)
 	agg.Add(190, 2451.123)

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -39,9 +39,8 @@ var (
 	numChunks          = flag.Int("numchunks", 5, "number of chunks to keep in memory. should be at least 1 more than what's needed to satisfy aggregation rules")
 	warmUpPeriod       = flag.Int("warm-up-period", 3600, "number of seconds before secondary nodes start serving requests")
 
-	maxUnwrittenChunks = flag.Int("max-unwritten-chunks", 1, "number of chunks per metric waiting to be written to cassandra.")
-
 	cassandraWriteConcurrency = flag.Int("cassandra-write-concurrency", 50, "max number of concurrent writes to cassandra.")
+	cassandraWriteQueueSize   = flag.Int("cassandra-write-queue-size", 100000, "write queue size. should be large engough to hold all at least the total number of series expected.")
 	cassandraPort             = flag.Int("cassandra-port", 9042, "cassandra port")
 	cassandraAddrs            = flag.String("cassandra-addrs", "", "cassandra host (may be given multiple times as comma-separated list)")
 	metricTTL                 = flag.Int("ttl", 3024000, "seconds before metrics are removed from cassandra")
@@ -234,7 +233,7 @@ func main() {
 		log.Fatal(4, "Failed to create NSQ consumer. %s", err)
 	}
 
-	metrics = NewAggMetrics(uint32(*chunkSpan), uint32(*numChunks), uint32(*chunkMaxStale), uint32(*metricMaxStale), uint32(*maxUnwrittenChunks), finalSettings)
+	metrics = NewAggMetrics(uint32(*chunkSpan), uint32(*numChunks), uint32(*chunkMaxStale), uint32(*metricMaxStale), uint32(*metricTTL), finalSettings)
 	metaCache = NewMetaCache()
 	handler := NewHandler(metrics, metaCache)
 	consumer.AddConcurrentHandlers(handler, *concurrency)

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -39,7 +39,7 @@ var (
 	numChunks          = flag.Int("numchunks", 5, "number of chunks to keep in memory. should be at least 1 more than what's needed to satisfy aggregation rules")
 	warmUpPeriod       = flag.Int("warm-up-period", 3600, "number of seconds before secondary nodes start serving requests")
 
-	cassandraWriteConcurrency = flag.Int("cassandra-write-concurrency", 50, "max number of concurrent writes to cassandra.")
+	cassandraWriteConcurrency = flag.Int("cassandra-write-concurrency", 10, "max number of concurrent writes to cassandra.")
 	cassandraWriteQueueSize   = flag.Int("cassandra-write-queue-size", 100000, "write queue size. should be large engough to hold all at least the total number of series expected.")
 	cassandraPort             = flag.Int("cassandra-port", 9042, "cassandra port")
 	cassandraAddrs            = flag.String("cassandra-addrs", "", "cassandra host (may be given multiple times as comma-separated list)")


### PR DESCRIPTION
New approach uses a pool of worker goroutines to process all chunks.

The change here removes the per-series channel to limit the number of un-saved chunks that can be present.  Instead of queues per series, there is now just 1 writeQueue (buffered channel) shared by all series.  As a result this single writeQueue should be quite large, large enough to hold all outstanding writes.  If we wanted to hold 10 unwritten chunks then the queue would need to be ~10x the number of series.  So if there were 100k series and we wanted to have up to 10chunks unwritten, the queue size (cassandraWriteQueueSize) would need to be 1million.  The amount of memory needed for this is actually less then the amount needed for 100k individial queues with a size of 10.



