### PR TITLE
refactor how metricPersist messages are sent.

### DIFF
--- a/metric_tank/cassandra.go
+++ b/metric_tank/cassandra.go
@@ -108,12 +108,7 @@ func processWriteQueue() {
 				if err == nil {
 					success = true
 					c.chunk.Saved = true
-					msg := &PersistMessage{
-						Instance: *instance,
-						Key:      c.key,
-						T0:       c.chunk.T0,
-					}
-					msg.Send()
+					SendPersistMessage(c.key, c.chunk.T0)
 					log.Debug("save complete. %s:%d %v", c.key, c.chunk.T0, c.chunk)
 					chunkSaveOk.Inc(1)
 				} else {


### PR DESCRIPTION
Sending many hundreds of thousands of persist messages in a short
time interval is putting too much load on our nsqd servers. This
change now batches the messages and just flushes once every second.