### PR TITLE
WEEKEND EXPERIMENT, NOT SERIOUS: benchmarks for simulated chunk write load on boltDB

### DIFF
--- a/metric_tank/bolt_test.go
+++ b/metric_tank/bolt_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/boltdb/bolt"
+	"math/rand"
+	"os"
+	"sort"
+	"testing"
+)
+
+var keysRand [][]byte
+var keysSort [][]byte
+var keysRevSort [][]byte
+
+type sortableKeys [][]byte
+
+func (s sortableKeys) Less(i, j int) bool {
+	return string(s[i]) < string(s[j])
+}
+
+func (s sortableKeys) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s sortableKeys) Len() int {
+	return len(s)
+}
+
+func init() {
+	// the keys themselves are random, so in random order, so we can just iterate this slice in sequence
+	// to simulate the random writes
+	keysRand = make([][]byte, 1000000)
+	keysSort = make([][]byte, 1000000)
+	keysRevSort = make([][]byte, 1000000)
+	for i := 0; i < 1000000; i++ {
+		keysRand[i] = randKey(10)
+	}
+	copy(keysSort, keysRand)
+	copy(keysRevSort, keysRand)
+	s := sortableKeys(keysSort)
+	sort.Sort(s)
+	keysSort = [][]byte(s)
+	sort.Reverse(s)
+	keysRevSort = [][]byte(s)
+}
+
+// returns a chunk for testing of 100Bytes
+func getChunk(id int) []byte {
+	b := bytes.NewBuffer([]byte(fmt.Sprintf("%20d", id)))
+	_, err := b.Write([]byte("11111111112222222222333333333344444444445555555555666666666677777777778888888888"))
+	if err != nil {
+		panic(err)
+	}
+	return b.Bytes()
+}
+
+// see http://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randKey(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Int63()%int64(len(letters))]
+	}
+	return b
+}
+
+func BenchmarkBoltWrite1kRandMetrics(b *testing.B) {
+	benchmarkBoltWrite(keysRand[0:1000], b)
+}
+func BenchmarkBoltWrite100kRandMetrics(b *testing.B) {
+	benchmarkBoltWrite(keysRand[0:100000], b)
+}
+func BenchmarkBoltWrite1kSortMetrics(b *testing.B) {
+	benchmarkBoltWrite(keysSort[0:1000], b)
+}
+func BenchmarkBoltWrite100kSortMetrics(b *testing.B) {
+	benchmarkBoltWrite(keysSort[0:100000], b)
+}
+func BenchmarkBoltWrite1kRevSortMetrics(b *testing.B) {
+	benchmarkBoltWrite(keysRevSort[0:1000], b)
+}
+func BenchmarkBoltWrite100kRevSortMetrics(b *testing.B) {
+	benchmarkBoltWrite(keysRevSort[0:100000], b)
+}
+func benchmarkBoltWrite(keys [][]byte, b *testing.B) {
+	fname := fmt.Sprintf("test-%d.db", len(keys))
+	db, err := bolt.Open(fname, 0600, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+	db.Update(func(tx *bolt.Tx) error {
+		for metric := 0; metric < len(keys); metric++ {
+			_, err := tx.CreateBucketIfNotExists(keys[metric])
+			if err != nil {
+				return fmt.Errorf("create bucket: %s", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	b.StartTimer()
+	// N is number of chunks.
+	db.Update(func(tx *bolt.Tx) error {
+		for chunk := 0; chunk < b.N; chunk++ {
+			//fmt.Print(chunk)
+			for metric := 0; metric < len(keys); metric++ {
+				b := tx.Bucket(keys[metric])
+				err := b.Put([]byte(string(chunk)), getChunk(chunk))
+				if err != nil {
+					return err
+				}
+				//if metric%(len(keys)/50) == 0 {
+				//		fmt.Print(".")
+				//	}
+			}
+			//fmt.Println()
+			b.SetBytes(int64(len(keys)) * 100)
+		}
+		return nil
+	})
+	b.StopTimer()
+	printB := func(bytes int64) string {
+		if bytes < 4096 {
+			return fmt.Sprintf("%d B", bytes)
+		} else if bytes < 4096*1024 {
+			return fmt.Sprintf("%d KiB", bytes/1024)
+		} else if bytes < 4096*1024*10024 {
+			return fmt.Sprintf("%d MiB", bytes/1024/1024)
+		} else {
+			return fmt.Sprintf("%d GiB", bytes/1024/1024/1024)
+		}
+	}
+	totalB := int64(len(keys) * 100 * b.N)
+	st, err := os.Stat(fname)
+	if err != nil {
+		panic(err)
+	}
+	b.Logf("wrote %s -- filesize %s", printB(totalB), printB(st.Size()))
+	os.Remove(fname)
+	/*	for chunk := 0; chunk < b.N; chunk++ {
+			for metric := 0; metric < m; metric++ {
+				db.View(func(tx *bolt.Tx) error {
+					b := tx.Bucket(metricKeys[metric])
+					v := b.Get([]byte(string(chunk)))
+					fmt.Printf("The answer is: %s\n", v)
+					return nil
+				})
+			}
+		}
+	*/
+}


### PR DESCRIPTION
some people are interested in a plain-file backend for MT,
instead of cassandra.  especially @torkelo 
So Boltdb is an option, probably not the best option because
it focuses on simplicity, not performance. especially not random write performance.
But an option nonetheless.

some thoughts:

* database filesize seems a bit on the large side. It allocates in increments of 4kB,
  starting at 1MiB I think, and double in size when it needs more space,
  upto 1GB where it allocates another 1GB. But the filesize is multiples of what it should be.
* all in one file, so definitely no stat/open/close overhead like whisper has, but harder to manage too.
  it would be interesting to consider a database file per metric or something, but then fd's becomes a problem.   unless you tune your system to keep all fd's open at all times, but then it's a bit harder to set up again.  multiple files would also allow for write concurrency. currently writes are serialized.
* bucket / metric key ordering doesn't seem to matter much, but having fewer metrics (keys) definitely helps
* there may be a warmup effect that i'm missing because longer benches makes the large-amount-of-metrics case definitely faster, but only for sorted metrics.
* I have an SSD in my laptop. i think bolt syncs after every write tx. 
i have put comparable (or so i think) dd write loads (which are of course 100% sequential) below.
the ability to write chunks (which comprise multiple points) for more than 100k metrics in under a second is not bad, but building this out into a reliable storage backend is a whole other thing.

for comparison:
```
~ ❯❯❯ dd if=/dev/zero of=foobar bs=$((100*1000)) count=1024 conv=fsync
1024+0 records in
1024+0 records out
102400000 bytes (102 MB) copied, 0.627705 s, 163 MB/s
~ ❯❯❯ dd if=/dev/zero of=foobar bs=$((100*100000)) count=10 conv=fsync
10+0 records in
10+0 records out
100000000 bytes (100 MB) copied, 0.685826 s, 146 MB/s
```

```
~/g/s/g/r/r/metric_tank ❯❯❯ go test -run=XX -bench=Bolt -benchmem -v
PASS
BenchmarkBoltWrite1kRandMetrics-8     	     300	   7308619 ns/op	  13.68 MB/s	 2317963 B/op	   30443 allocs/op
--- BENCH: BenchmarkBoltWrite1kRandMetrics-8
	bolt_test.go:144: wrote 97 KiB -- filesize 1024 KiB
	bolt_test.go:144: wrote 4 MiB -- filesize 16 MiB
	bolt_test.go:144: wrote 28 MiB -- filesize 128 MiB
BenchmarkBoltWrite100kRandMetrics-8   	       1	10087950104 ns/op	   0.99 MB/s	440620104 B/op	 6702128 allocs/op
--- BENCH: BenchmarkBoltWrite100kRandMetrics-8
	bolt_test.go:144: wrote 9 MiB -- filesize 64 MiB
BenchmarkBoltWrite1kSortMetrics-8     	     200	   6635132 ns/op	  15.07 MB/s	 2123775 B/op	   28349 allocs/op
--- BENCH: BenchmarkBoltWrite1kSortMetrics-8
	bolt_test.go:144: wrote 97 KiB -- filesize 1024 KiB
	bolt_test.go:144: wrote 4 MiB -- filesize 16 MiB
	bolt_test.go:144: wrote 19 MiB -- filesize 64 MiB
BenchmarkBoltWrite100kSortMetrics-8   	       1	2082651506 ns/op	   4.80 MB/s	440667808 B/op	 6702956 allocs/op
--- BENCH: BenchmarkBoltWrite100kSortMetrics-8
	bolt_test.go:144: wrote 9 MiB -- filesize 64 MiB
BenchmarkBoltWrite1kRevSortMetrics-8  	     200	   6857164 ns/op	  14.58 MB/s	 2123966 B/op	   28353 allocs/op
--- BENCH: BenchmarkBoltWrite1kRevSortMetrics-8
	bolt_test.go:144: wrote 97 KiB -- filesize 1024 KiB
	bolt_test.go:144: wrote 9 MiB -- filesize 32 MiB
	bolt_test.go:144: wrote 19 MiB -- filesize 64 MiB
BenchmarkBoltWrite100kRevSortMetrics-8	       1	2355477511 ns/op	   4.25 MB/s	440625784 B/op	 6702387 allocs/op
--- BENCH: BenchmarkBoltWrite100kRevSortMetrics-8
	bolt_test.go:144: wrote 9 MiB -- filesize 64 MiB
ok  	github.com/raintank/raintank-metric/metric_tank	23.115s
~/g/s/g/r/r/metric_tank ❯❯❯ go test -run=XX -bench=Bolt -benchmem -v -benchtime=10s
PASS
BenchmarkBoltWrite1kRandMetrics-8     	    2000	   6677119 ns/op	  14.98 MB/s	 2998741 B/op	   40889 allocs/op
--- BENCH: BenchmarkBoltWrite1kRandMetrics-8
	bolt_test.go:144: wrote 97 KiB -- filesize 1024 KiB
	bolt_test.go:144: wrote 9 MiB -- filesize 32 MiB
	bolt_test.go:144: wrote 190 MiB -- filesize 512 MiB
BenchmarkBoltWrite100kRandMetrics-8   	       1	10990397465 ns/op	   0.91 MB/s	440576232 B/op	 6701671 allocs/op
--- BENCH: BenchmarkBoltWrite100kRandMetrics-8
	bolt_test.go:144: wrote 9 MiB -- filesize 64 MiB
BenchmarkBoltWrite1kSortMetrics-8     	    2000	   7451214 ns/op	  13.42 MB/s	 2998678 B/op	   40888 allocs/op
--- BENCH: BenchmarkBoltWrite1kSortMetrics-8
	bolt_test.go:144: wrote 97 KiB -- filesize 1024 KiB
	bolt_test.go:144: wrote 9 MiB -- filesize 32 MiB
	bolt_test.go:144: wrote 190 MiB -- filesize 512 MiB
BenchmarkBoltWrite100kSortMetrics-8   	      20	 685555803 ns/op	  14.59 MB/s	231512832 B/op	 3249416 allocs/op
--- BENCH: BenchmarkBoltWrite100kSortMetrics-8
	bolt_test.go:144: wrote 9 MiB -- filesize 64 MiB
	bolt_test.go:144: wrote 47 MiB -- filesize 256 MiB
	bolt_test.go:144: wrote 95 MiB -- filesize 512 MiB
	bolt_test.go:144: wrote 190 MiB -- filesize 512 MiB
BenchmarkBoltWrite1kRevSortMetrics-8  	    2000	   7308598 ns/op	  13.68 MB/s	 2998717 B/op	   40888 allocs/op
--- BENCH: BenchmarkBoltWrite1kRevSortMetrics-8
	bolt_test.go:144: wrote 97 KiB -- filesize 1024 KiB
	bolt_test.go:144: wrote 9 MiB -- filesize 32 MiB
	bolt_test.go:144: wrote 190 MiB -- filesize 512 MiB
BenchmarkBoltWrite100kRevSortMetrics-8	      20	 653131492 ns/op	  15.31 MB/s	231508104 B/op	 3249330 allocs/op
--- BENCH: BenchmarkBoltWrite100kRevSortMetrics-8
	bolt_test.go:144: wrote 9 MiB -- filesize 64 MiB
	bolt_test.go:144: wrote 47 MiB -- filesize 256 MiB
	bolt_test.go:144: wrote 95 MiB -- filesize 512 MiB
	bolt_test.go:144: wrote 190 MiB -- filesize 512 MiB
ok  	github.com/raintank/raintank-metric/metric_tank	122.283s
```