### PR TITLE
Update ProbeEvent schema.

### DIFF
--- a/eventdef/eventdef.go
+++ b/eventdef/eventdef.go
@@ -74,7 +74,8 @@ func InitElasticsearch(addr, user, pass string, w chan *BulkSaveStatus, bulkMaxD
 								"type": "string"
 							},
 							"match_mapping_type": "string",
-							"umatch": "message"
+							"umatch": "message",
+							"path_unmatch": "tags.*"
 						}
 					},
 					{
@@ -87,6 +88,18 @@ func InitElasticsearch(addr, user, pass string, w chan *BulkSaveStatus, bulkMaxD
 								"index_options": "docs"
 							},
 							"match": "message"
+						}
+					},
+					{
+						"tag_values": {
+							"mapping": {
+								"type": "string",
+								"norms": {
+									"enabled": false
+								},
+								"index_options": "docs"
+							},
+							"path_match": "tags.*"
 						}
 					}
 				]

--- a/msg/format.go
+++ b/msg/format.go
@@ -9,3 +9,8 @@ const (
 	FormatMetricDataArrayJson Format = iota
 	FormatMetricDataArrayMsgp
 )
+
+const (
+	FormatProbeEventJson Format = iota
+	FormatProbeEventMsgp
+)

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/codeskyblue/go-uuid"
 	"github.com/raintank/raintank-metric/schema"
 )
 
@@ -17,6 +19,25 @@ type MetricData struct {
 	Produced time.Time
 	Format   Format
 	Msg      []byte
+}
+
+type ProbeEvent struct {
+	Id       int64
+	Produced time.Time
+	Event    *schema.ProbeEvent
+	Format   Format
+	Msg      []byte
+}
+
+type ProbeEventJson struct {
+	Id        string   `json:"id"`
+	EventType string   `json:"event_type"`
+	OrgId     int64    `json:"org_id"`
+	Severity  string   `json:"severity"`
+	Source    string   `json:"source"`
+	Timestamp int64    `json:"timestamp"`
+	Message   string   `json:"message"`
+	Tags      []string `json:"tags"`
 }
 
 // parses format and id (cheap), but doesn't decode metrics (expensive) just yet.
@@ -77,6 +98,96 @@ func CreateMsg(metrics []*schema.MetricData, id int64, version Format) ([]byte, 
 	case FormatMetricDataArrayMsgp:
 		m := schema.MetricDataArray(metrics)
 		msg, err = m.MarshalMsg(nil)
+	default:
+		return nil, errors.New("unsupported version")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal metrics payload: %s", err)
+	}
+	_, err = buf.Write(msg)
+	if err != nil {
+		return nil, fmt.Errorf("buf.Write failed: %s", err.Error())
+	}
+	return buf.Bytes(), nil
+}
+
+func ProbeEventFromMsg(msg []byte) (*ProbeEvent, error) {
+	e := &ProbeEvent{
+		Event: &schema.ProbeEvent{},
+		Msg:   msg,
+	}
+	if len(msg) < 9 {
+		return e, errors.New("msg too small")
+	}
+
+	buf := bytes.NewReader(msg[1:9])
+	binary.Read(buf, binary.BigEndian, &e.Id)
+	e.Produced = time.Unix(0, e.Id)
+
+	format := Format(msg[0])
+	if format != FormatProbeEventJson && format != FormatProbeEventMsgp {
+		return e, errors.New("unknown format")
+	}
+	e.Format = format
+	return e, nil
+}
+
+func (e *ProbeEvent) DecodeProbeEvent() error {
+	var err error
+	switch e.Format {
+	case FormatProbeEventJson:
+		oldFormat := &ProbeEventJson{}
+		err = json.Unmarshal(e.Msg[9:], oldFormat)
+		//convert our []string of key:valy pairs to
+		// map[string]string
+		tags := make(map[string]string)
+		for _, t := range oldFormat.Tags {
+			parts := strings.SplitN(t, ":", 2)
+			tags[parts[0]] = parts[1]
+		}
+		e.Event = &schema.ProbeEvent{
+			Id:        oldFormat.Id,
+			EventType: oldFormat.EventType,
+			OrgId:     oldFormat.OrgId,
+			Severity:  oldFormat.Severity,
+			Source:    oldFormat.Source,
+			Timestamp: oldFormat.Timestamp,
+			Message:   oldFormat.Message,
+			Tags:      tags,
+		}
+	case FormatProbeEventMsgp:
+		_, err = e.Event.UnmarshalMsg(e.Msg[9:])
+	default:
+		return fmt.Errorf("unrecognized format %d", e.Msg[0])
+	}
+	if err != nil {
+		return fmt.Errorf("ERROR: failure to unmarshal message body via format %q: %s", e.Format, err)
+	}
+	return nil
+}
+
+func CreateProbeEventMsg(event *schema.ProbeEvent, id int64, version Format) ([]byte, error) {
+	if event.Id == "" {
+		// per http://blog.mikemccandless.com/2014/05/choosing-fast-unique-identifier-uuid.html,
+		// using V1 UUIDs is much faster than v4 like we were using
+		u := uuid.NewUUID()
+		event.Id = u.String()
+	}
+	buf := new(bytes.Buffer)
+	err := binary.Write(buf, binary.LittleEndian, uint8(version))
+	if err != nil {
+		return nil, fmt.Errorf("binary.Write failed: %s", err.Error())
+	}
+	err = binary.Write(buf, binary.BigEndian, id)
+	if err != nil {
+		return nil, fmt.Errorf("binary.Write failed: %s", err.Error())
+	}
+	var msg []byte
+	switch version {
+	case FormatProbeEventJson:
+		msg, err = json.Marshal(event)
+	case FormatProbeEventMsgp:
+		msg, err = event.MarshalMsg(nil)
 	default:
 		return nil, errors.New("unsupported version")
 	}

--- a/schema/event.go
+++ b/schema/event.go
@@ -5,15 +5,17 @@ import (
 	"strings"
 )
 
+//go:generate msgp
+
 type ProbeEvent struct {
-	Id        string   `json:"id"`
-	EventType string   `json:"event_type"`
-	OrgId     int64    `json:"org_id"`
-	Severity  string   `json:"severity"` // enum "INFO" "WARN" "ERROR" "OK"
-	Source    string   `json:"source"`
-	Timestamp int64    `json:"timestamp"`
-	Message   string   `json:"message"`
-	Tags      []string `json:"tags" elastic:"type:string,index:not_analyzed"`
+	Id        string            `json:"id"`
+	EventType string            `json:"event_type"`
+	OrgId     int64             `json:"org_id"`
+	Severity  string            `json:"severity"` // enum "INFO" "WARN" "ERROR" "OK"
+	Source    string            `json:"source"`
+	Timestamp int64             `json:"timestamp"`
+	Message   string            `json:"message"`
+	Tags      map[string]string `json:"tags"`
 }
 
 func (e *ProbeEvent) Validate() error {

--- a/schema/event_gen.go
+++ b/schema/event_gen.go
@@ -1,0 +1,320 @@
+package schema
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// DecodeMsg implements msgp.Decodable
+func (z *ProbeEvent) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, err = dc.ReadMapHeader()
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Id":
+			z.Id, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "EventType":
+			z.EventType, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "OrgId":
+			z.OrgId, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		case "Severity":
+			z.Severity, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Source":
+			z.Source, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Timestamp":
+			z.Timestamp, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		case "Message":
+			z.Message, err = dc.ReadString()
+			if err != nil {
+				return
+			}
+		case "Tags":
+			var msz uint32
+			msz, err = dc.ReadMapHeader()
+			if err != nil {
+				return
+			}
+			if z.Tags == nil && msz > 0 {
+				z.Tags = make(map[string]string, msz)
+			} else if len(z.Tags) > 0 {
+				for key, _ := range z.Tags {
+					delete(z.Tags, key)
+				}
+			}
+			for msz > 0 {
+				msz--
+				var xvk string
+				var bzg string
+				xvk, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				bzg, err = dc.ReadString()
+				if err != nil {
+					return
+				}
+				z.Tags[xvk] = bzg
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *ProbeEvent) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 8
+	// write "Id"
+	err = en.Append(0x88, 0xa2, 0x49, 0x64)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Id)
+	if err != nil {
+		return
+	}
+	// write "EventType"
+	err = en.Append(0xa9, 0x45, 0x76, 0x65, 0x6e, 0x74, 0x54, 0x79, 0x70, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.EventType)
+	if err != nil {
+		return
+	}
+	// write "OrgId"
+	err = en.Append(0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.OrgId)
+	if err != nil {
+		return
+	}
+	// write "Severity"
+	err = en.Append(0xa8, 0x53, 0x65, 0x76, 0x65, 0x72, 0x69, 0x74, 0x79)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Severity)
+	if err != nil {
+		return
+	}
+	// write "Source"
+	err = en.Append(0xa6, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Source)
+	if err != nil {
+		return
+	}
+	// write "Timestamp"
+	err = en.Append(0xa9, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.Timestamp)
+	if err != nil {
+		return
+	}
+	// write "Message"
+	err = en.Append(0xa7, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65)
+	if err != nil {
+		return err
+	}
+	err = en.WriteString(z.Message)
+	if err != nil {
+		return
+	}
+	// write "Tags"
+	err = en.Append(0xa4, 0x54, 0x61, 0x67, 0x73)
+	if err != nil {
+		return err
+	}
+	err = en.WriteMapHeader(uint32(len(z.Tags)))
+	if err != nil {
+		return
+	}
+	for xvk, bzg := range z.Tags {
+		err = en.WriteString(xvk)
+		if err != nil {
+			return
+		}
+		err = en.WriteString(bzg)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *ProbeEvent) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 8
+	// string "Id"
+	o = append(o, 0x88, 0xa2, 0x49, 0x64)
+	o = msgp.AppendString(o, z.Id)
+	// string "EventType"
+	o = append(o, 0xa9, 0x45, 0x76, 0x65, 0x6e, 0x74, 0x54, 0x79, 0x70, 0x65)
+	o = msgp.AppendString(o, z.EventType)
+	// string "OrgId"
+	o = append(o, 0xa5, 0x4f, 0x72, 0x67, 0x49, 0x64)
+	o = msgp.AppendInt64(o, z.OrgId)
+	// string "Severity"
+	o = append(o, 0xa8, 0x53, 0x65, 0x76, 0x65, 0x72, 0x69, 0x74, 0x79)
+	o = msgp.AppendString(o, z.Severity)
+	// string "Source"
+	o = append(o, 0xa6, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65)
+	o = msgp.AppendString(o, z.Source)
+	// string "Timestamp"
+	o = append(o, 0xa9, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70)
+	o = msgp.AppendInt64(o, z.Timestamp)
+	// string "Message"
+	o = append(o, 0xa7, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65)
+	o = msgp.AppendString(o, z.Message)
+	// string "Tags"
+	o = append(o, 0xa4, 0x54, 0x61, 0x67, 0x73)
+	o = msgp.AppendMapHeader(o, uint32(len(z.Tags)))
+	for xvk, bzg := range z.Tags {
+		o = msgp.AppendString(o, xvk)
+		o = msgp.AppendString(o, bzg)
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ProbeEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Id":
+			z.Id, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "EventType":
+			z.EventType, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "OrgId":
+			z.OrgId, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "Severity":
+			z.Severity, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Source":
+			z.Source, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Timestamp":
+			z.Timestamp, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "Message":
+			z.Message, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "Tags":
+			var msz uint32
+			msz, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				return
+			}
+			if z.Tags == nil && msz > 0 {
+				z.Tags = make(map[string]string, msz)
+			} else if len(z.Tags) > 0 {
+				for key, _ := range z.Tags {
+					delete(z.Tags, key)
+				}
+			}
+			for msz > 0 {
+				var xvk string
+				var bzg string
+				msz--
+				xvk, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				bzg, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Tags[xvk] = bzg
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *ProbeEvent) Msgsize() (s int) {
+	s = 1 + 3 + msgp.StringPrefixSize + len(z.Id) + 10 + msgp.StringPrefixSize + len(z.EventType) + 6 + msgp.Int64Size + 9 + msgp.StringPrefixSize + len(z.Severity) + 7 + msgp.StringPrefixSize + len(z.Source) + 10 + msgp.Int64Size + 8 + msgp.StringPrefixSize + len(z.Message) + 5 + msgp.MapHeaderSize
+	if z.Tags != nil {
+		for xvk, bzg := range z.Tags {
+			_ = bzg
+			s += msgp.StringPrefixSize + len(xvk) + msgp.StringPrefixSize + len(bzg)
+		}
+	}
+	return
+}

--- a/schema/event_gen_test.go
+++ b/schema/event_gen_test.go
@@ -1,0 +1,125 @@
+package schema
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMarshalUnmarshalProbeEvent(t *testing.T) {
+	v := ProbeEvent{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgProbeEvent(b *testing.B) {
+	v := ProbeEvent{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgProbeEvent(b *testing.B) {
+	v := ProbeEvent{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalProbeEvent(b *testing.B) {
+	v := ProbeEvent{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeProbeEvent(t *testing.T) {
+	v := ProbeEvent{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := ProbeEvent{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeProbeEvent(b *testing.B) {
+	v := ProbeEvent{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeProbeEvent(b *testing.B) {
+	v := ProbeEvent{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
New schema uses an object '{key:value, key2:value2}' for tags
instead of an array of strings '["key:value", "key2:value2"]'.
This change supports receiving legacy version of the probeEvent,
converting it to the new format before saving to ES.  ProbeEvents
using the new format should be sent over the wire encoded via
msgpack instead of json.