### PR TITLE
WIP (needs testing) log when defcache backfill is ready & start NSQ consumption. fix #116

### DIFF
--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -219,14 +219,15 @@ func main() {
 	}
 	cfg.MaxInFlight = *maxInFlight
 
+	metrics = NewAggMetrics(store, uint32(*chunkSpan), uint32(*numChunks), uint32(*chunkMaxStale), uint32(*metricMaxStale), uint32(*metricTTL), finalSettings)
+	defCache = NewDefCache()
+	handler := NewHandler(metrics, defCache)
+	log.Info("DefCache initialized. starting data consumption")
+
 	consumer, err := insq.NewConsumer(*topic, *channel, cfg, "%s", stats)
 	if err != nil {
 		log.Fatal(4, "Failed to create NSQ consumer. %s", err)
 	}
-
-	metrics = NewAggMetrics(store, uint32(*chunkSpan), uint32(*numChunks), uint32(*chunkMaxStale), uint32(*metricMaxStale), uint32(*metricTTL), finalSettings)
-	defCache = NewDefCache()
-	handler := NewHandler(metrics, defCache)
 	consumer.AddConcurrentHandlers(handler, *concurrency)
 
 	nsqdAdds := strings.Split(*nsqdTCPAddrs, ",")


### PR DESCRIPTION
as an operator, in order to be able to properly manage and promote MT
instances, you need to know from which point on MT is reliably
taking in new data.
There's two ways to achieve this:
* async defcache backfill, which means it'll take in data pretty much
  straight after starting. but then the backfill is actually not very
  useful and may cause an ES overload
* synchronous defcache backfill. whih is currently implemented,
  but the problem was that an nsq backlog would form and it wasn't
  clear at which point the backlog clears.  as long as there's a backlog
  messages could have been dropped, because nsq doesn't deliver in
  order.
  so by starting the consumer only when we're ready to process messages,
  we can practically mark that as the time the operator needs to know.

==> so now as an operator, when you see
"DefCache initialized. starting data consumption"
from then on, you know MT will have the data.