### PR TITLE
Optimize http json encoding

### DIFF
--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -24,26 +24,31 @@ type Series struct {
 	Interval   uint32
 }
 
-func (s *Series) MarshalJSON() ([]byte, error) {
+func graphiteJSON(series []Series) ([]byte, error) {
 	var b []byte
-	b = append(b, `{"Target":"`...)
-	b = append(b, s.Target...)
-	b = append(b, `","Datapoints":[`...)
-	for _, p := range s.Datapoints {
-		b = append(b, '[')
-		if math.IsNaN(p.Val) {
-			b = append(b, `null,`...)
-		} else {
-			b = strconv.AppendFloat(b, p.Val, 'f', 3, 64)
-			b = append(b, ',')
+	b = append(b, '[')
+	for _, s := range series {
+		b = append(b, `{"Target":"`...)
+		b = append(b, s.Target...)
+		b = append(b, `","Datapoints":[`...)
+		for _, p := range s.Datapoints {
+			b = append(b, '[')
+			if math.IsNaN(p.Val) {
+				b = append(b, `null,`...)
+			} else {
+				b = strconv.AppendFloat(b, p.Val, 'f', 3, 64)
+				b = append(b, ',')
+			}
+			b = strconv.AppendUint(b, uint64(p.Ts), 10)
+			b = append(b, `],`...)
 		}
-		b = strconv.AppendUint(b, uint64(p.Ts), 10)
-		b = append(b, `],`...)
+		b = b[:len(b)-1] // cut last comma
+		b = append(b, `],"Interval":`...)
+		b = strconv.AppendInt(b, int64(s.Interval), 10)
+		b = append(b, `},`...)
 	}
 	b = b[:len(b)-1] // cut last comma
-	b = append(b, `],"Interval":`...)
-	b = strconv.AppendInt(b, int64(s.Interval), 10)
-	b = append(b, '}')
+	b = append(b, ']')
 	return b, nil
 }
 

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/grafana/grafana/pkg/log"
@@ -26,26 +25,26 @@ type Series struct {
 }
 
 func (s *Series) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	buf.WriteString(`{"Target":"`)
-	buf.WriteString(s.Target)
-	buf.WriteString(`","Datapoints":[`)
+	var b []byte
+	b = append(b, `{"Target":"`...)
+	b = append(b, s.Target...)
+	b = append(b, `","Datapoints":[`...)
 	for _, p := range s.Datapoints {
-		buf.WriteString(`[`)
+		b = append(b, '[')
 		if math.IsNaN(p.Val) {
-			buf.WriteString(`null,`)
+			b = append(b, `null,`...)
 		} else {
-			buf.WriteString(strconv.FormatFloat(p.Val, 'f', 3, 64))
-			buf.WriteString(`,`)
+			b = strconv.AppendFloat(b, p.Val, 'f', 3, 64)
+			b = append(b, ',')
 		}
-		buf.WriteString(strconv.FormatUint(uint64(p.Ts), 10))
-		buf.WriteString(`],`)
+		b = strconv.AppendUint(b, uint64(p.Ts), 10)
+		b = append(b, `],`...)
 	}
-	buf.Truncate(buf.Len() - 1) // cut last comma
-	buf.WriteString(`],"Interval":`)
-	buf.WriteString(strconv.FormatInt(int64(s.Interval), 10))
-	buf.WriteString(`}`)
-	return buf.Bytes(), nil
+	b = b[:len(b)-1] // cut last comma
+	b = append(b, `],"Interval":`...)
+	b = strconv.AppendInt(b, int64(s.Interval), 10)
+	b = append(b, '}')
+	return b, nil
 }
 
 func get(store Store, defCache *DefCache, aggSettings []aggSetting) http.HandlerFunc {

--- a/metric_tank/http_test.go
+++ b/metric_tank/http_test.go
@@ -28,7 +28,8 @@ func TestJsonMarshal(t *testing.T) {
 			Interval: 10,
 		},
 	}
-	js, err := graphiteJSON(data)
+	js := bufPool.Get().([]byte)
+	js, err := graphiteJSON(js, data)
 	if err != nil {
 		panic(err)
 	}
@@ -37,6 +38,7 @@ func TestJsonMarshal(t *testing.T) {
 	if exp != got {
 		t.Fatalf("bad json output.\nexpected:%s\ngot:     %s\n", exp, got)
 	}
+	bufPool.Put(js[:0])
 }
 
 func BenchmarkSeriesJson(b *testing.B) {
@@ -55,10 +57,12 @@ func BenchmarkSeriesJson(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		js, err := graphiteJSON(data)
+		js := bufPool.Get().([]byte)
+		js, err := graphiteJSON(js, data)
 		if err != nil || len(js) < 1000 {
 			panic(err)
 		}
+		bufPool.Put(js[:0])
 	}
 }
 
@@ -85,9 +89,11 @@ func BenchmarkHttpRespJson(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		js, err := graphiteJSON(data)
+		js := bufPool.Get().([]byte)
+		js, err := graphiteJSON(js, data)
 		if err != nil || len(js) < 1000 {
 			panic(err)
 		}
+		bufPool.Put(js[:0])
 	}
 }

--- a/metric_tank/http_test.go
+++ b/metric_tank/http_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestJsonMarshal(t *testing.T) {
+	data := []Series{
+		{
+			Target: "a",
+			Datapoints: []Point{
+				{123, 60},
+				{10000, 120},
+				{0, 180},
+				{1, 240},
+			},
+			Interval: 60,
+		},
+		{
+			Target: "foo(bar)",
+			Datapoints: []Point{
+				{123.456, 10},
+				{123.7, 20},
+				{124.10, 30},
+				{125.0, 40},
+				{126.0, 50},
+			},
+			Interval: 10,
+		},
+	}
+	js, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	exp := `[{"Target":"a","Datapoints":[[123.000000,60],[10000.000000,120],[0.000000,180],[1.000000,240]],"Interval":60},{"Target":"foo(bar)","Datapoints":[[123.456000,10],[123.700000,20],[124.100000,30],[125.000000,40],[126.000000,50]],"Interval":10}]`
+	got := string(js)
+	if exp != got {
+		t.Fatalf("bad json output.\nexpected:%s\ngot:     %s\n", exp, got)
+	}
+}
+
+func BenchmarkSeriesJson(b *testing.B) {
+	pA := make([]Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		pA[i] = Point{float64(10000 * i), uint32(baseTs + 10*i)}
+	}
+	data := Series{
+		Target:     "some.metric.with.a-whole-bunch-of.integers",
+		Datapoints: pA,
+		Interval:   10,
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		js, err := json.Marshal(data)
+		if err != nil || len(js) < 1000 {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkHttpRespJson(b *testing.B) {
+	pA := make([]Point, 1000, 1000)
+	pB := make([]Point, 1000, 1000)
+	baseTs := 1500000000
+	for i := 0; i < 1000; i++ {
+		pA[i] = Point{float64(10000 * i), uint32(baseTs + 10*i)}
+		pB[i] = Point{12.34 * float64(i), uint32(baseTs + 10*i)}
+	}
+	data := []Series{
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.integers",
+			Datapoints: pA,
+			Interval:   10,
+		},
+		{
+			Target:     "some.metric.with.a-whole-bunch-of.floats",
+			Datapoints: pB,
+			Interval:   10,
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		js, err := json.Marshal(data)
+		if err != nil || len(js) < 1000 {
+			panic(err)
+		}
+	}
+}

--- a/metric_tank/http_test.go
+++ b/metric_tank/http_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 )
 
@@ -29,7 +28,7 @@ func TestJsonMarshal(t *testing.T) {
 			Interval: 10,
 		},
 	}
-	js, err := json.Marshal(data)
+	js, err := graphiteJSON(data)
 	if err != nil {
 		panic(err)
 	}
@@ -46,15 +45,17 @@ func BenchmarkSeriesJson(b *testing.B) {
 	for i := 0; i < 1000; i++ {
 		pA[i] = Point{float64(10000 * i), uint32(baseTs + 10*i)}
 	}
-	data := Series{
-		Target:     "some.metric.with.a-whole-bunch-of.integers",
-		Datapoints: pA,
-		Interval:   10,
+	data := []Series{
+		Series{
+			Target:     "some.metric.with.a-whole-bunch-of.integers",
+			Datapoints: pA,
+			Interval:   10,
+		},
 	}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		js, err := json.Marshal(data)
+		js, err := graphiteJSON(data)
 		if err != nil || len(js) < 1000 {
 			panic(err)
 		}
@@ -84,7 +85,7 @@ func BenchmarkHttpRespJson(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		js, err := json.Marshal(data)
+		js, err := graphiteJSON(data)
 		if err != nil || len(js) < 1000 {
 			panic(err)
 		}

--- a/metric_tank/http_test.go
+++ b/metric_tank/http_test.go
@@ -33,7 +33,7 @@ func TestJsonMarshal(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	exp := `[{"Target":"a","Datapoints":[[123.000000,60],[10000.000000,120],[0.000000,180],[1.000000,240]],"Interval":60},{"Target":"foo(bar)","Datapoints":[[123.456000,10],[123.700000,20],[124.100000,30],[125.000000,40],[126.000000,50]],"Interval":10}]`
+	exp := `[{"Target":"a","Datapoints":[[123.000,60],[10000.000,120],[0.000,180],[1.000,240]],"Interval":60},{"Target":"foo(bar)","Datapoints":[[123.456,10],[123.700,20],[124.100,30],[125.000,40],[126.000,50]],"Interval":10}]`
 	got := string(js)
 	if exp != got {
 		t.Fatalf("bad json output.\nexpected:%s\ngot:     %s\n", exp, got)


### PR DESCRIPTION
finally, i've been able to make nice progress with memprofiling.
you can follow the progress by reading the individual commit messages,
all combined, the http responses now take 27% of the time it used to take to generate.
and memory usage is also significantly lower.
due to the effects of GC we may not see too much of that, meaning, the previously excessive mem allocations were cleared soon after anyway. but i presume due to the concurrency mem was pushed up and gc doesn't reclaim it.
it looks like we'll be able to cut at least 20% memory (see below)

```
$ go tool pprof --alloc_objects metric_tank_metric-tank-1.prod.raintank.io profile_heap_metric-tank-1.prod.raintank.io                                             ⏎
Entering interactive mode (type "help" for commands)
(pprof) top100
90373267553 of 94857876129 total (95.27%)
Dropped 326 nodes (cum <= 474289380)
      flat  flat%   sum%        cum   cum%
17238135420 18.17% 18.17% 22875766599 24.12%  main.(*Point).MarshalJSON
12051538220 12.70% 30.88% 26679608822 28.13%  fmt.Sprintf
(...)

~$ go tool pprof --alloc_space metric_tank_metric-tank-1.prod.raintank.io profile_heap_metric-tank-1.prod.raintank.io                                               ⏎
Entering interactive mode (type "help" for commands)
(pprof) top100
5726786.79MB of 5961945.02MB total (96.06%)
Dropped 318 nodes (cum <= 29809.73MB)
      flat  flat%   sum%        cum   cum%
1448819.46MB 24.30% 24.30% 1448819.46MB 24.30%  bytes.makeSlice
828278.66MB 13.89% 38.19% 1053447.68MB 17.67%  fmt.Sprintf
515645.71MB  8.65% 46.84% 933415.16MB 15.66%  encoding/json.compact <---
406750.31MB  6.82% 53.67% 935817.71MB 15.70%  main.getSeries
371714.57MB  6.23% 59.90% 371963.08MB  6.24%  github.com/nsqio/go-nsq.ReadResponse
348802.94MB  5.85% 65.75% 520850.69MB  8.74%  main.(*Point).MarshalJSON <---
(...)

```

pretty excited to see the impact of this on QA (or prod).
should see a drop in both cpu and mem.

@woodsaj check it out!

cc @dgryski 