### PR TITLE
make MetricData Id logic more solid

### DIFF
--- a/metric_tank/defcache.go
+++ b/metric_tank/defcache.go
@@ -69,9 +69,8 @@ func (dc *DefCache) Backfill() {
 }
 
 func (dc *DefCache) Add(metric *schema.MetricData) {
-	id := metric.GetId()
 	dc.Lock()
-	mdef, ok := dc.defs[id]
+	mdef, ok := dc.defs[metric.Id]
 	dc.Unlock()
 	if ok {
 		//If the time diff between this datapoint and the lastUpdate

--- a/metric_tank/handler.go
+++ b/metric_tank/handler.go
@@ -37,11 +37,14 @@ func (h *Handler) HandleMessage(m *nsq.Message) error {
 	metricsReceived.Inc(int64(len(ms.Metrics)))
 
 	for _, metric := range ms.Metrics {
+		if metric.Id == "" {
+			panic("empty metric.Id")
+		}
 		if metric.Time == 0 {
-			log.Warn("invalid metric. metric.Time is 0. %s", metric.GetId())
+			log.Warn("invalid metric. metric.Time is 0. %s", metric.Id)
 		} else {
 			h.defCache.Add(metric)
-			m := h.metrics.GetOrCreate(metric.GetId())
+			m := h.metrics.GetOrCreate(metric.Id)
 			m.Add(uint32(metric.Time), metric.Value)
 		}
 	}

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -28,24 +28,14 @@ type MetricData struct {
 // returns a id (hash key) in the format OrgId.md5Sum
 // the md5sum is a hash of the the concatination of the
 // series name + each tag key:value pair, sorted alphabetically.
-func (m *MetricData) GetId() string {
-	id := m.Id
-	if id == "" {
-		var buffer bytes.Buffer
-		buffer.WriteString(m.Name)
-		sort.Strings(m.Tags)
-		for _, k := range m.Tags {
-			buffer.WriteString(fmt.Sprintf(";%s", k))
-		}
-		id = fmt.Sprintf("%d.%x", m.OrgId, md5.Sum(buffer.Bytes()))
-	}
-	return id
-}
-
 func (m *MetricData) SetId() {
-	if m.Id == "" {
-		m.Id = m.GetId()
+	var buffer bytes.Buffer
+	buffer.WriteString(m.Name)
+	sort.Strings(m.Tags)
+	for _, k := range m.Tags {
+		buffer.WriteString(fmt.Sprintf(";%s", k))
 	}
+	m.Id = fmt.Sprintf("%d.%x", m.OrgId, md5.Sum(buffer.Bytes()))
 }
 
 // can be used by some encoders, such as msgp
@@ -91,7 +81,7 @@ func MetricDefinitionFromMetricData(d *MetricData) *MetricDefinition {
 		nodesMap[key] = n
 	}
 	return &MetricDefinition{
-		Id:         d.GetId(),
+		Id:         d.Id,
 		Name:       d.Name,
 		OrgId:      d.OrgId,
 		Metric:     d.Metric,


### PR DESCRIPTION
@woodsaj looks good to you?

* SetId should always set id.
  we can't trust anyone sending metrics, they could
  mess with the id field.

* most often/always id won't be set yet when SetId() called,
  no need to waste cycles branching and calling other functions

* when GetId was called repeatedly and id was not set,
  it would compute the id over and over again because it didn't save it.

* no need for temp var id that just represents m.Id

* Furthermore, I would argue that callers of this library should know if
  the Id needs to be (re)set and whether or not it should already be set.
  (in all places where GetId() is called - currently MT's defcache and
  handler - it absolutely should have been set),
  so no need for conditional branching.
  in fact the old approach would hide bugs where the id wasn't
  set yet even though it totally should have been. I rather have it
  crash.
  So we can just query .Id field instead of function call