### PR TITLE
Golang1.6 circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ test:
     - pkg/package.sh
 dependencies:
   pre:
-    - if [[ ! -e /usr/local/go-1.6 ]]; then mv /usr/local/go /usr/local/go-1.5.1; wget https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz && tar -C /usr/local -zxf go1.6.linux-amd64.tar.gz && mv /usr/local/go /usr/local/go-1.6 && ln -s /usr/local/go-1.6 /usr/local/go; fi
+    - if [[ ! -e /usr/local/go-1.6 ]]; then sudo mv /usr/local/go /usr/local/go-1.5.1; wget https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz && sudo tar -C /usr/local -zxf go1.6.linux-amd64.tar.gz && sudo mv /usr/local/go /usr/local/go-1.6 && sudo ln -s /usr/local/go-1.6 /usr/local/go; fi
   override:
     - pkg/depends.sh
     - pkg/build.sh

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ test:
   post:
     - pkg/package.sh
 dependencies:
+  pre:
+    - if [[ ! -e /usr/local/go-1.6 ]]; then mv /usr/local/go /usr/local/go-1.5.1; wget https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz && tar -C /usr/local -zxf go1.6.linux-amd64.tar.gz && mv /usr/local/go /usr/local/go-1.6 && ln -s /usr/local/go-1.6 /usr/local/go; fi
   override:
     - pkg/depends.sh
     - pkg/build.sh

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -71,6 +71,8 @@ var (
 	defCache *DefCache
 
 	startupTime time.Time
+
+	GitHash 	 = "(none)"
 )
 
 func init() {
@@ -154,7 +156,7 @@ func main() {
 	}
 
 	if *showVersion {
-		fmt.Println("metrics_tank")
+		fmt.Printf("metrics_tank (built with %s, git hash %s)\n", runtime.Version(), GitHash)
 		return
 	}
 	if *instance == "" {

--- a/nsq_probe_events_to_elasticsearch/nsq_probe_events_to_elasticsearch.go
+++ b/nsq_probe_events_to_elasticsearch/nsq_probe_events_to_elasticsearch.go
@@ -8,6 +8,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -56,6 +57,7 @@ var (
 	msgsHandleFail met.Count
 
 	writeQueue *InProgressMessageQueue
+	GitHash = "(none)"
 )
 
 type ESHandler struct {
@@ -176,7 +178,7 @@ func main() {
 	log.NewLogger(0, "console", fmt.Sprintf(`{"level": %d, "formatting":true}`, *logLevel))
 
 	if *showVersion {
-		fmt.Println("nsq_probe_events_to_elasticsearch")
+		fmt.Printf("nsq_probe_events_to_elasticsearch (built with %s, git hash %s)\n", runtime.Version(), GitHash)
 		return
 	}
 

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -6,8 +6,9 @@ cd ${DIR}
 
 : ${GOPATH:="${HOME}/.go_workspace"}
 export PATH=$GOPATH/bin:$PATH
+GIT_HASH=`git rev-parse HEAD`
 
 for VAR in nsq_probe_events_to_elasticsearch metric_tank; do
-	go install github.com/raintank/raintank-metric/$VAR
+	go install -ldflags "-X main.GitHash $GIT_HASH" github.com/raintank/raintank-metric/$VAR
 	cp $(which $VAR) ${DIR}/artifacts
 done


### PR DESCRIPTION
Installs golang 1.6 in the circleci container, and prints out the version of go used to build the binary & the git hash of the source of the current binary.