### PR TITLE
Parallelized get target

### DIFF
--- a/metric_tank/aggmetric.go
+++ b/metric_tank/aggmetric.go
@@ -214,6 +214,7 @@ func (a *AggMetric) GetAggregated(consolidator consolidation.Consolidator, aggSp
 // more data then what's requested may be included
 // also returns oldest point we have, so that if your query needs data before it, the caller knows when to query cassandra
 func (a *AggMetric) Get(from, to uint32) (uint32, []Iter) {
+	pre := time.Now()
 	log.Debug("AggMetric %s Get(): %d - %d (%s - %s) span:%ds", a.Key, from, to, TS(from), TS(to), to-from-1)
 	if from >= to {
 		panic("invalid request. to must > from")
@@ -334,6 +335,7 @@ func (a *AggMetric) Get(from, to uint32) (uint32, []Iter) {
 	chunk := a.getChunk(oldestPos)
 	iters = append(iters, NewIter(chunk.Iter(), "mem %s", chunk))
 
+	memToIterDuration.Value(time.Now().Sub(pre))
 	return oldestChunk.T0, iters
 }
 

--- a/metric_tank/dataprocessor.go
+++ b/metric_tank/dataprocessor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/raintank/raintank-metric/metric_tank/consolidation"
 	"math"
 	"runtime"
+	"sync"
 	"time"
 )
 
@@ -137,6 +138,48 @@ func consolidate(in []Point, aggNum uint32, consolidator consolidation.Consolida
 // but never more than maxPoints
 func aggEvery(numPoints, maxPoints uint32) uint32 {
 	return (numPoints + maxPoints - 1) / maxPoints
+}
+
+// error is the error of the first failing target request
+func getTargets(store Store, reqs []Req) ([]Series, error) {
+	seriesChan := make(chan Series, len(reqs))
+	errorsChan := make(chan error, len(reqs))
+	// TODO: abort pending requests on error, maybe use context, maybe timeouts too
+	wg := sync.WaitGroup{}
+	wg.Add(len(reqs))
+	for _, req := range reqs {
+		go func(wg *sync.WaitGroup, req Req) {
+			pre := time.Now()
+			points, interval, err := getTarget(store, req)
+			if err != nil {
+				errorsChan <- err
+			} else {
+				getTargetDuration.Value(time.Now().Sub(pre))
+				seriesChan <- Series{
+					Target:     req.key,
+					Datapoints: points,
+					Interval:   interval,
+				}
+			}
+			wg.Done()
+		}(&wg, req)
+	}
+	go func() {
+		wg.Wait()
+		close(seriesChan)
+		close(errorsChan)
+	}()
+	out := make([]Series, 0, len(reqs))
+	var err error
+	for series := range seriesChan {
+		out = append(out, series)
+	}
+	for e := range errorsChan {
+		err = e
+		break
+	}
+	return out, err
+
 }
 
 func getTarget(store Store, req Req) (points []Point, interval uint32, err error) {

--- a/metric_tank/dataprocessor.go
+++ b/metric_tank/dataprocessor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/raintank/raintank-metric/metric_tank/consolidation"
 	"math"
 	"runtime"
+	"time"
 )
 
 // doRecover is the handler that turns panics into returns from the top level of getTarget.
@@ -270,6 +271,7 @@ func getSeries(store Store, key string, consolidator consolidation.Consolidator,
 	} else {
 		reqSpanMem.Value(int64(toUnix - fromUnix))
 	}
+	pre := time.Now()
 	iters = append(iters, memIters...)
 
 	points := make([]Point, 0)
@@ -286,5 +288,6 @@ func getSeries(store Store, key string, consolidator consolidation.Consolidator,
 		}
 		log.Debug("getSeries: iter %s  values good/total %d/%d", iter.cmt, good, total)
 	}
+	itersToPointsDuration.Value(time.Now().Sub(pre))
 	return points
 }

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -176,12 +176,14 @@ func Get(w http.ResponseWriter, req *http.Request, store Store, defCache *DefCac
 	for i, req := range reqs {
 		log.Debug("===================================")
 		log.Debug("HTTP Get()          %s", req)
+		pre := time.Now()
 		points, interval, err := getTarget(store, req)
 		if err != nil {
 			log.Error(0, err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		getTargetDuration.Value(time.Now().Sub(pre))
 
 		out[i] = Series{
 			Target:     targets[i],

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -172,25 +172,17 @@ func Get(w http.ResponseWriter, req *http.Request, store Store, defCache *DefCac
 		return
 	}
 
-	out := make([]Series, len(reqs))
-	for i, req := range reqs {
+	for _, req := range reqs {
 		log.Debug("===================================")
 		log.Debug("HTTP Get()          %s", req)
-		pre := time.Now()
-		points, interval, err := getTarget(store, req)
-		if err != nil {
-			log.Error(0, err.Error())
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		getTargetDuration.Value(time.Now().Sub(pre))
-
-		out[i] = Series{
-			Target:     targets[i],
-			Datapoints: points,
-			Interval:   interval,
-		}
 	}
+	out, err := getTargets(store, reqs)
+	if err != nil {
+		log.Error(0, err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	js := bufPool.Get().([]byte)
 	js, err = graphiteJSON(js, out)
 	if err != nil {

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -100,6 +100,11 @@ var cassWriters met.Gauge
 var cassPutDuration met.Timer
 var cassBlockDuration met.Timer
 var cassGetDuration met.Timer
+var memToIterDuration met.Timer
+var getTargetDuration met.Timer
+var itersToPointsDuration met.Timer
+var cassToIterDuration met.Timer
+
 var persistDuration met.Timer
 var messagesSize met.Meter
 var metricsPerMessage met.Meter
@@ -336,6 +341,10 @@ func initMetrics(stats met.Backend) {
 	cassWriteQueueSize = stats.NewGauge("cassandra.write_queue.size", int64(*cassandraWriteQueueSize))
 	cassWriters = stats.NewGauge("cassandra.num_writers", int64(*cassandraWriteConcurrency))
 	cassGetDuration = stats.NewTimer("cassandra.get_duration", 0)
+	memToIterDuration = stats.NewTimer("mem.to_iter_duration", 0)
+	getTargetDuration = stats.NewTimer("get_target_duration", 0)
+	itersToPointsDuration = stats.NewTimer("iters_to_points_duration", 0)
+	cassToIterDuration = stats.NewTimer("cassandra.to_iter_duration", 0)
 	cassBlockDuration = stats.NewTimer("cassandra.block_duration", 0)
 	cassPutDuration = stats.NewTimer("cassandra.put_duration", 0)
 	persistDuration = stats.NewTimer("persist_duration", 0)

--- a/metric_tank/store_cassandra.go
+++ b/metric_tank/store_cassandra.go
@@ -240,6 +240,7 @@ func (c *cassandraStore) Search(key string, start, end uint32) ([]Iter, error) {
 		cassGetDuration.Value(time.Now().Sub(pre))
 		close(results)
 	}()
+	pre = time.Now()
 
 	for o := range results {
 		outcomes = append(outcomes, o)
@@ -281,6 +282,7 @@ func (c *cassandraStore) Search(key string, start, end uint32) ([]Iter, error) {
 			log.Error(3, "cassandra query error. %s", err)
 		}
 	}
+	cassToIterDuration.Value(time.Now().Sub(pre))
 	cassRowsPerResponse.Value(int64(len(outcomes)))
 	log.Debug("searchCassandra(): %d outcomes (queries), %d total iters", len(outcomes), len(iters))
 	return iters, nil


### PR DESCRIPTION
6de5e3b2ab70317a7da2e638e2a5be87e89ba965 has shown great speed differences when graphing just one series.
When we deployed this to prod, where one typically renders 20ish series, things were still surprisingly slow.

I added some more metrics and verified that the parallel approach is much faster when you have several series.

approach taken:
1) use fake_metrics_to_nsq to backfill 1 month of dummy data for 1 org with 20 keys perorg:
```
/fake_metrics_to_nsq -keys-per-org 20 -orgs 1 -statsd-addr statsdaemon:8125 -nsqd-tcp-address nsqd:4150 -offset 31536000 -steps 1000 -interval 1
```
(i actually wanted to do a year but MT/nsqd started blocking and things failed, and i ended up with a bit less than a month but that's fine)
2) create a grafana dashboard that plots `some.id.of.a.metric.*` for this 1 month period:
![fake-dash](https://cloud.githubusercontent.com/assets/20774/13311845/f429c988-dbe5-11e5-864c-9a4af6f3709f.png)

3) restart MT from scratch so that it's not affected by previous ingest load
4) do a bunch of requests
5) visualize the duration metrics
6) rinse and repeat, switching to different commit hash, building and using that MT
metric is run with default args as in raintank-docker except no aggregation
```
./metric_tank \
	--chunkspan 600 \
	--numchunks 3 \
	--statsd-addr statsdaemon:8125 \
	--nsqd-tcp-address nsqd:4150 \
	--listen :6063 \
	--primary-node \
	--elastic-addr elasticsearch:9200 \
	--cassandra-addrs cassandra \
	&>> /var/log/raintank/nsq_metrics_tank.log &
```

(i did do a separate run with debug logging enabled to make sure it was doing runtime consolidation)


on the image you can see a bunch of requests with new code, then old, then new again.
note that the individual steps themselves are quite a bit slower then when executing serially, but all combined the duration of the total operation (red line on top) shows the picture as the user experiences it.  the parallel code takes us from 9s to 2.5s.

![perf-parallelize](https://cloud.githubusercontent.com/assets/20774/13311808/9d9299d8-dbe5-11e5-9e8b-b875aa8b6751.png)
