### PR TITLE
controllable read concurrency

### DIFF
--- a/metric_tank/cwr.go
+++ b/metric_tank/cwr.go
@@ -2,6 +2,14 @@ package main
 
 import "time"
 
+type ChunkReadRequest struct {
+	month   uint32
+	sortKey uint32
+	q       string
+	p       []interface{}
+	out     chan outcome
+}
+
 type ChunkWriteRequest struct {
 	key       string
 	chunk     *Chunk

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -62,7 +62,9 @@ var (
 	cassandraAddrs            = flag.String("cassandra-addrs", "", "cassandra host (may be given multiple times as comma-separated list)")
 	cassandraConsistency      = flag.String("cassandra-consistency", "one", "write consistency (any|one|two|three|quorum|all|local_quorum|each_quorum|local_one")
 	cassandraTimeout          = flag.Int("cassandra-timeout", 1000, "cassandra timeout in milliseconds")
+	cassandraReadConcurrency  = flag.Int("cassandra-read-concurrency", 20, "max number of concurrent reads to cassandra.")
 	cassandraWriteConcurrency = flag.Int("cassandra-write-concurrency", 10, "max number of concurrent writes to cassandra.")
+	cassandraReadQueueSize    = flag.Int("cassandra-read-queue-size", 100, "max number of outstanding reads before blocking. value doesn't matter much")
 	cassandraWriteQueueSize   = flag.Int("cassandra-write-queue-size", 100000, "write queue size per cassandra worker. should be large engough to hold all at least the total number of series expected, divided by how many workers you have")
 
 	esAddr    = flag.String("elastic-addr", "localhost:9200", "elasticsearch address for metric definitions")
@@ -248,7 +250,7 @@ func main() {
 		finalSettings = append(finalSettings, aggSetting{aggSpan, aggChunkSpan, aggNumChunks, aggTTL, ready})
 	}
 
-	store, err := NewCassandraStore(stats, *cassandraAddrs, *cassandraConsistency, *cassandraTimeout, *cassandraWriteConcurrency)
+	store, err := NewCassandraStore(stats, *cassandraAddrs, *cassandraConsistency, *cassandraTimeout, *cassandraReadConcurrency, *cassandraWriteConcurrency)
 	if err != nil {
 		log.Fatal(4, "failed to initialize cassandra. %s", err)
 	}


### PR DESCRIPTION
i whipped this up pretty fast.  didn't do much testing, except something similar i did to #158 except i had 1 years worth of data, but only 1 series. i think 1 vs many series shouldn't matter much.

i ran `while true; do curl -H 'X-Org-Id: 1' 'http://localhost:8888/render?target=some.id.of.a.metric.1&from=-1y&until=now&format=json&maxDataPoints=1920' > /dev/null; done`
and ran MT in these different modes:
previous code, and then concurrency of 20, 10, 5 ,2,1
i also loaded the chart manually a couple times each run to check the data appeared fine.
![meh](https://cloud.githubusercontent.com/assets/20774/13460405/65d16a18-e0ce-11e5-8459-5245d44c3d40.png)
what we're seeing is that as we bring down read concurrency it gets slower.  i don't know why it only starts to affect the outcome once it goes under 5 or so. i do know why the difference is so small compared to in #158 : iters-to-points is a big bottleneck and this is still executed sequentially (at least on a per-target level, so when you fetch multiple targets at once this is less of an issue)


