### PR TITLE
support a very limited graphite render api

### DIFF
--- a/metric_tank/README.md
+++ b/metric_tank/README.md
@@ -48,3 +48,4 @@ when one primary is down you need to be careful about when to promote a secondar
 
 * `/render` has a very, very limited subset of the graphite render api. basically you can specify targets by their graphite key, set from, to and maxDataPoints, and use consolidateBy.
 No other function or parameter is currently supported.  Also we don't check org-id so don't expose this publically
+* `/metrics/index.json` is like graphite.  Don't expose this publically

--- a/metric_tank/README.md
+++ b/metric_tank/README.md
@@ -12,12 +12,14 @@
     * from is inclusive, to is exclusive.
     * so from=x, to=y returns data that can include x and y-1 but not y.
     * from defaults to now-24h, to to now+1.
+    * from can also be a human friendly pattern like -10min or -7d
 
 * the response will id the series by the target used to request them
 
 note:
 * it just serves up the data that it has, in timestamp ascending order. it does no effort to try to fill in gaps.
 * no support for wildcards, patterns, "magic" time specs like "-10min" etc.
+* it is assumed that authorisation (by org-id) has already been performed.  (the graphite-raintank plugin does this)
 
 ## other useful endpoints exemplified through curl commands:
 
@@ -40,3 +42,9 @@ when one primary is down you need to be careful about when to promote a secondar
 * after you see the "starting data consumption" log message for a primary, data consomuption starts. this timestamp is important.
 * look at your largest chunkSpan. secondary can only be promoted when a new interval starts for the largest chunkSpan. intervals start when clock unix timestamp divides without remainder by chunkSpan. How long you should wait is also shown (in seconds) via the `cluster.promotion_wait` metric.
 * of course there are other factors: any running primary should be depromoted and have saved its data to cassandra, all metricPersist message should have made it through NSQ into the about-to-be-promoted instance.
+
+
+# graphite-api
+
+* `/render` has a very, very limited subset of the graphite render api. basically you can specify targets by their graphite key, set from, to and maxDataPoints, and use consolidateBy.
+No other function or parameter is currently supported.  Also we don't check org-id so don't expose this publically

--- a/metric_tank/defcache.go
+++ b/metric_tank/defcache.go
@@ -135,3 +135,15 @@ func (dc *DefCache) UpdateReq(req *Req) error {
 	}
 	return nil
 }
+
+func (dc *DefCache) List() []*schema.MetricDefinition {
+	dc.RLock()
+	out := make([]*schema.MetricDefinition, len(dc.defsByKey))
+	i := 0
+	for _, md := range dc.defsByKey {
+		out[i] = md
+		i++
+	}
+	dc.RUnlock()
+	return out
+}

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -259,11 +259,11 @@ func Get(w http.ResponseWriter, req *http.Request, store Store, defCache *DefCac
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	bufPool.Put(js[:0])
 
 	w.Header().Set("Content-Type", "application/json")
 	reqHandleDuration.Value(time.Now().Sub(pre))
 	w.Write(js)
+	bufPool.Put(js[:0])
 }
 
 // report ApplicationStatus for use by loadBalancer healthChecks.

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -261,6 +261,7 @@ func Get(w http.ResponseWriter, req *http.Request, store Store, defCache *DefCac
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	reqHandleDuration.Value(time.Now().Sub(pre))
 	w.Write(js)
 	bufPool.Put(js[:0])

--- a/metric_tank/http_test.go
+++ b/metric_tank/http_test.go
@@ -68,7 +68,7 @@ func TestJsonMarshal(t *testing.T) {
 	}
 	js := bufPool.Get().([]byte)
 	for _, c := range cases {
-		js, err := graphiteJSON(js[:0], c.in)
+		js, err := graphiteRaintankJSON(js[:0], c.in)
 		if err != nil {
 			panic(err)
 		}
@@ -98,7 +98,7 @@ func BenchmarkSeriesJson(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		js := bufPool.Get().([]byte)
-		js, err := graphiteJSON(js, data)
+		js, err := graphiteRaintankJSON(js, data)
 		if err != nil || len(js) < 1000 {
 			panic(err)
 		}
@@ -131,7 +131,7 @@ func BenchmarkHttpRespJson(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		js := bufPool.Get().([]byte)
-		js, err := graphiteJSON(js, data)
+		js, err := graphiteRaintankJSON(js, data)
 		if err != nil || len(js) < 1000 {
 			panic(err)
 		}

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -325,6 +325,7 @@ func main() {
 		http.HandleFunc("/", appStatus)
 		http.HandleFunc("/get", get(store, defCache, finalSettings, logMinDur))          // metric-tank native api which deals with ID's, not target strings
 		http.HandleFunc("/render", getLegacy(store, defCache, finalSettings, logMinDur)) // traditional graphite api
+		http.HandleFunc("/metrics/index.json", IndexJson(defCache))
 		http.HandleFunc("/cluster", clusterStatusHandler)
 		log.Info("starting listener for metrics and http/debug on %s", *listenAddr)
 		log.Info("%s", http.ListenAndServe(*listenAddr, nil))

--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -323,7 +323,8 @@ func main() {
 
 	go func() {
 		http.HandleFunc("/", appStatus)
-		http.HandleFunc("/get", get(store, defCache, finalSettings, logMinDur))
+		http.HandleFunc("/get", get(store, defCache, finalSettings, logMinDur))          // metric-tank native api which deals with ID's, not target strings
+		http.HandleFunc("/render", getLegacy(store, defCache, finalSettings, logMinDur)) // traditional graphite api
 		http.HandleFunc("/cluster", clusterStatusHandler)
 		log.Info("starting listener for metrics and http/debug on %s", *listenAddr)
 		log.Info("%s", http.ListenAndServe(*listenAddr, nil))

--- a/metric_tank/req.go
+++ b/metric_tank/req.go
@@ -8,7 +8,7 @@ import (
 type Req struct {
 	// these fields can be set straight away:
 	key          string // metric key, often same as target
-	target       string // original input string like consolidateBy(key,'sum')
+	target       string // original input string like consolidateBy(key,'sum'). used in output so that graphite doesn't get confused
 	from         uint32
 	to           uint32
 	maxPoints    uint32


### PR DESCRIPTION
very useful for production setups where you have clusters of graphite's,
haproxies etc, and you want to point grafana to a specific metric tank
instance.  With this endpoint you can bypass all the complexity and talk
right to the instance you want.