### PR TITLE
fix #180

### DIFF
--- a/metric_tank/dataprocessor.go
+++ b/metric_tank/dataprocessor.go
@@ -45,6 +45,11 @@ func fix(in []schema.Point, from, to, interval uint32) []schema.Point {
 
 	// last point should be the last value that divides by interval lower than to (because to is always exclusive)
 	lastPoint := (to - 1) - ((to - 1) % interval)
+
+	if lastPoint < start {
+		// the requested range is too narrow for the requested interval
+		return []schema.Point{}
+	}
 	out := make([]schema.Point, (lastPoint-start)/interval+1)
 
 	// i iterates in. o iterates out. t is the ts we're looking to fill.

--- a/metric_tank/dataprocessor_test.go
+++ b/metric_tank/dataprocessor_test.go
@@ -318,6 +318,25 @@ func TestFix(t *testing.T) {
 			10,
 			[]schema.Point{{1, 10}, {2, 20}, {math.NaN(), 30}},
 		},
+		{
+			// interval > from-to span with empty input.  saw this one in prod
+			// 1458966240 divides by 60 but is too low
+			// 1458966300 divides by 60 but is too high
+			// so there is no point in range, so output must be empty
+			[]schema.Point{},
+			1458966244, // 1458966240 divides by 60 but is too low
+			1458966274, // 1458966300 divides by 60 but is too high
+			60,
+			[]schema.Point{},
+		},
+		{
+			// let's try a similar case but now there is a point in range
+			[]schema.Point{},
+			1458966234,
+			1458966264,
+			60,
+			[]schema.Point{{math.NaN(), 1458966240}},
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
fix() can get into a case where lastpoint < start, which causes a uint
overflow which causes allocation of a huge slice of len ~70M
see #180