### PR TITLE
Lower gc pressure

### DIFF
--- a/metric_tank/dataprocessor.go
+++ b/metric_tank/dataprocessor.go
@@ -12,10 +12,12 @@ import (
 	"time"
 )
 
+const defaultPointSliceSize = 2000
+
 var pointSlicePool = sync.Pool{
 	// default size is probably bigger than what most responses need, but it saves [re]allocations
 	// also it's possible that occasionnally more size is needed, causing a realloc of underlying array, and that extra space will stick around until next GC run.
-	New: func() interface{} { return make([]schema.Point, 2000) },
+	New: func() interface{} { return make([]schema.Point, 0, defaultPointSliceSize) },
 }
 
 // doRecover is the handler that turns panics into returns from the top level of getTarget.

--- a/metric_tank/http.go
+++ b/metric_tank/http.go
@@ -289,7 +289,11 @@ func Get(w http.ResponseWriter, req *http.Request, store Store, defCache *DefCac
 	} else {
 		js, err = graphiteRaintankJSON(js, out)
 	}
+	for _, serie := range out {
+		pointSlicePool.Put(serie.Datapoints[:0])
+	}
 	if err != nil {
+		bufPool.Put(js[:0])
 		log.Error(0, err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/msg/msg.go
+++ b/msg/msg.go
@@ -19,7 +19,7 @@ var errFmtBinWriteFailed = "binary write failed: %q"
 var errFmtUnknownFormat = "unknown format %d"
 
 var mdPool = sync.Pool{
-	New: func() interface{} { return make(schema.MetricDataArray, 5) }, // default size probably too small, but after some automatic reallocations should be well-tuned for real load
+	New: func() interface{} { return make(schema.MetricDataArray, 0, 5) }, // default size probably too small, but after some automatic reallocations should be well-tuned for real load
 }
 
 type MetricData struct {


### PR DESCRIPTION
replaces https://github.com/raintank/raintank-metric/pull/133

key metrics to look for are allocation speed (in red) and GC runs/duration (to the extent visible), which are driven by the former
before:
https://snapshot.raintank.io/dashboard/snapshot/kwXDypH4JMU1ML9QA61jb8ofA6Eq19ht
1nd commit is the run on the right (better), 2nd commit on the left (best):
https://snapshot.raintank.io/dashboard/snapshot/Jeic0ZbYrK6TVL1MgNyCOogBM4VVuPJc

cpu picture also shows the improvement
(note runs are in reverse order. from last to oldest)
show only NMT on the charts for max clarity
https://snapshot.raintank.io/dashboard/snapshot/mznNs5G2eWQHKWOIEfWXzUOj3hK3Uskb