### PR TITLE
better handling of bulkindex errors

### DIFF
--- a/metric_tank/metric_tank.go
+++ b/metric_tank/metric_tank.go
@@ -202,7 +202,7 @@ func main() {
 		*cassandraAddrs = "localhost"
 	}
 
-	defs, err := metricdef.NewDefsEs(*esAddr, "", "", *indexName)
+	defs, err := metricdef.NewDefsEs(*esAddr, "", "", *indexName, nil)
 	if err != nil {
 		log.Fatal(4, "failed to initialize Elasticsearch. %s", err)
 	}

--- a/metricdef/metricdef.go
+++ b/metricdef/metricdef.go
@@ -4,9 +4,12 @@ import (
 	"github.com/raintank/raintank-metric/schema"
 )
 
+type ResultCallback func(id string, ok bool)
+
 type Defs interface {
 	GetMetrics(scroll_id string) ([]*schema.MetricDefinition, string, error)
 	GetMetricDefinition(id string) (*schema.MetricDefinition, bool, error)
 	IndexMetric(m *schema.MetricDefinition) error
+	SetAsyncResultCallback(fn ResultCallback) // asynchronous implementations use this to report the result back for each def id
 	Stop()
 }

--- a/metricdef/metricdef_concurrent_mock.go
+++ b/metricdef/metricdef_concurrent_mock.go
@@ -24,12 +24,17 @@ import (
 type DefsMockConcurrent struct {
 	sync.Mutex
 	defs map[string]*schema.MetricDefinition
+	cb   ResultCallback
 }
 
 func NewDefsMockConcurrent() *DefsMockConcurrent {
 	return &DefsMockConcurrent{
 		defs: make(map[string]*schema.MetricDefinition),
 	}
+}
+
+func (d *DefsMockConcurrent) SetAsyncResultCallback(fn ResultCallback) {
+	d.cb = fn
 }
 
 // this does not mimic ES's scroll mechanism, we can cut this corner for now.

--- a/metricdef/metricdef_mock.go
+++ b/metricdef/metricdef_mock.go
@@ -22,6 +22,7 @@ import (
 
 type DefsMock struct {
 	defs map[string]*schema.MetricDefinition
+	cb   ResultCallback
 }
 
 func NewDefsMock() *DefsMock {
@@ -44,6 +45,10 @@ func (d *DefsMock) GetMetrics(scroll_id string) ([]*schema.MetricDefinition, str
 func (d *DefsMock) IndexMetric(m *schema.MetricDefinition) error {
 	d.defs[m.Id] = m
 	return nil
+}
+
+func (d *DefsMock) SetAsyncResultCallback(fn ResultCallback) {
+	d.cb = fn
 }
 
 func (d *DefsMock) GetMetricDefinition(id string) (*schema.MetricDefinition, bool, error) {


### PR DESCRIPTION
thanks to this changeset, seeing plenty of

```
2016/05/16 16:50:53 [D] ES: 90.3b40d43c8e67ff9889484fa59e33e5f9 failed: es_rejected_execution_exception: "rejected execution of org.elasticsearch.transport.TransportService$4@52d62eed on EsThreadPoolExecutor[bulk, queue capacity = 50, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@3a6f7253[Running, pool size = 8, active threads = 8, queued tasks = 50, completed tasks = 280]]"

```

in dev stack, yeay :?